### PR TITLE
Extract uast per file instead of per feature

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     url="https://github.com/src-d/tm-experiments",
     packages=find_packages(exclude=["tests"]),
     entry_points={"console_scripts": ["tmexp=tmexp.__main__:main"]},
-    install_requires=["nltk==3.4.3", "pymysql==0.9.3"],
+    install_requires=["nltk==3.4.3", "pymysql==0.9.3", "bblfsh==3.0.4"],
     include_package_data=True,
     license="Apache-2.0",
     classifiers=[

--- a/tmexp/preprocess.py
+++ b/tmexp/preprocess.py
@@ -6,6 +6,7 @@ import re
 from typing import Any, Counter as CounterType, Dict, Iterator, Optional, Set, Tuple
 import warnings
 
+import bblfsh
 from nltk import PorterStemmer
 import pymysql
 import pymysql.cursors
@@ -22,16 +23,15 @@ WHERE r.repository_id = '{}' AND is_tag(rf.ref_name);
 GITBASE_EXTRACT_WORDS = """
 SELECT f.file_path,
        language(f.file_path, f.blob_content) as lang,
-       uast_extract(uast(f.blob_content,
-                         language(f.file_path, f.blob_content),
-                         '{}'),
-                    '{}') as words
+       uast(f.blob_content,
+            language(f.file_path, f.blob_content),
+            ('{}')) as uast
 FROM repositories r
     NATURAL JOIN refs rf
     NATURAL JOIN commits c
     NATURAL JOIN commit_files cf
     NATURAL JOIN files f
-WHERE r.repository_id = '{}' AND rf.ref_name='{}' AND words IS NOT NULL;
+WHERE r.repository_id = '{}' AND rf.ref_name='{}' AND uast IS NOT NULL;
 """
 
 ID = "identifiers"
@@ -47,9 +47,9 @@ LITERAL_KEY = "Value"
 COMMENT_KEY = "Text"
 
 FEATURE_MAPPING = {
-    ID: (IDENTIFIER_XPATH, IDENTIFIER_KEY),
-    LIT: (LITERAL_XPATH, LITERAL_KEY),
-    COM: (COMMENT_XPATH, COMMENT_KEY),
+    ID: {"xpath": IDENTIFIER_XPATH, "key": IDENTIFIER_KEY},
+    LIT: {"xpath": LITERAL_XPATH, "key": LITERAL_KEY},
+    COM: {"xpath": COMMENT_XPATH, "key": COMMENT_KEY},
 }
 
 
@@ -75,26 +75,46 @@ def extract(
 
 
 def process_row(
-    row: Dict[str, Any], tokenize: bool, stem: bool
-) -> Tuple[str, str, Dict[str, int]]:
+    row: Dict[str, Any], tokenize: bool, stem: bool, feature_dict: Dict[str, bool]
+) -> Tuple[str, str, Dict[str, Dict[str, int]]]:
     document = row["file_path"].decode()
     lang = row["lang"].decode()
-    words = row["words"].decode()[1:-1].split(",")
-    words = [w for word in words for w in word.split()]
-    if tokenize:
-        words = [w for word in words for w in word.split("_")]
-        words = [
-            w
-            for word in words
-            for w in re.findall(r"[A-Z]?[a-z]+|[A-Z]+(?=[A-Z]|$)", word)
-        ]
-    words = [word.lower() for word in words]
+    ctx = bblfsh.decode(row["uast"])
+    word_dict: Dict[str, Counter] = {
+        feature: Counter()
+        for feature, include_feature in feature_dict.items()
+        if include_feature
+    }
     if stem:
         stemmer = PorterStemmer()
-        words = [stemmer.stem(word) for word in words]
-    word_dict: CounterType[str] = Counter()
-    word_dict.update(words)
-    return document, lang, dict(word_dict)
+    for node in ctx.load():
+        for feature, uast_dict in FEATURE_MAPPING.items():
+            if (
+                node["@type"] not in uast_dict["xpath"]
+                or node[uast_dict["key"]] is None
+            ):
+                continue
+            words = node[uast_dict["key"]].split()
+            if tokenize:
+                words = [w for word in words for w in word.split("_")]
+                words = [
+                    w
+                    for word in words
+                    for w in re.findall(r"[A-Z]?[a-z]+|[A-Z]+(?=[A-Z]|$)", word)
+                ]
+            words = [word.lower() for word in words]
+            if stem:
+                words = [stemmer.stem(word) for word in words]
+            word_dict[feature].update(words)
+            break
+    return (
+        document,
+        lang,
+        {
+            feature: dict(feature_word_dict)
+            for feature, feature_word_dict in word_dict.items()
+        },
+    )
 
 
 def preprocess(
@@ -153,30 +173,31 @@ def preprocess(
             row["ref_name"].decode() for row in extract(host, port, user, password, sql)
         ]
         logger.info("Found {} tagged references.".format(len(refs)))
+        feature_dict = {ID: True, LIT: literals, COM: comments}
+        uast_xpath = " | ".join(
+            [
+                FEATURE_MAPPING[feature]["xpath"]
+                for feature, include_feature in feature_dict.items()
+                if include_feature
+            ]
+        )
         for ref in refs:
             doc_word_dict: Dict[str, Dict[str, Any]] = defaultdict(dict)
             logger.info("Processing '{}' ...".format(ref))
-            for feature, include_feature in {
-                ID: True,
-                LIT: literals,
-                COM: comments,
-            }.items():
-                if not include_feature:
-                    continue
-                logger.info("Extracting {} ...".format(feature))
-                uast_xpath, uast_key = FEATURE_MAPPING[feature]
-                sql = GITBASE_EXTRACT_WORDS.format(uast_xpath, uast_key, repo, ref)
-                lang_count: CounterType[str] = Counter()
-                for row in extract(host, port, user, password, sql):
-                    document, lang, word_dict = process_row(row, tokenize, stem)
-                    document_count += 1
-                    vocabulary = vocabulary.union(word_dict.keys())
-                    doc_word_dict[document][feature] = {"words": word_dict}
-                    doc_word_dict[document]["lang"] = lang
-                    lang_count[lang] += 1
-                logger.info("Extracted {} from:".format(feature))
-                for lang in sorted(lang_count):
-                    logger.info("   {} {} files.".format(lang_count[lang], lang))
+            sql = GITBASE_EXTRACT_WORDS.format(uast_xpath, repo, ref)
+            lang_count: CounterType[str] = Counter()
+            for row in extract(host, port, user, password, sql):
+                document, lang, word_dict = process_row(
+                    row, tokenize, stem, feature_dict
+                )
+                for word_feature_dict in word_dict.values():
+                    vocabulary = vocabulary.union(word_feature_dict.keys())
+                document_count += 1
+                doc_word_dict[document] = {"words": word_dict}
+                lang_count[lang] += 1
+            logger.info("Extracted words from:")
+            for lang in sorted(lang_count):
+                logger.info("   {} {} files.".format(lang_count[lang], lang))
             output_dict[repo][ref] = dict(doc_word_dict)
     logger.info(
         "Extracted {} distinct words from {} documents.".format(


### PR DESCRIPTION
Before we were extracting and parsing the UAST of each file once per feature and retrieving the extracted tokens.
Now we extract the UAST for each filence, retrieve nodes, and parse them using the bblfsh python lib instead of gitbase.

The output does not change, logs are less verbose, not separating between features.