### PR TITLE
Adding helpers and bblfsh error management

### DIFF
--- a/tmexp/__main__.py
+++ b/tmexp/__main__.py
@@ -106,16 +106,24 @@ def get_parser() -> argparse.ArgumentParser:
         "--no-stem", help="To skip stemming.", dest="stem", action="store_false"
     )
     preprocess_parser.add_argument(
-        "--gitbase-host", help="Gitbase hostname.", type=str, default="0.0.0.0"
+        "--gitbase-host",
+        help="Gitbase hostname.",
+        type=str,
+        default="0.0.0.0",
+        dest="host",
     )
     preprocess_parser.add_argument(
-        "--gitbase-port", help="Gitbase port.", type=int, default=3306
+        "--gitbase-port", help="Gitbase port.", type=int, default=3306, dest="port"
     )
     preprocess_parser.add_argument(
-        "--gitbase-user", help="Gitbase user.", type=str, default="root"
+        "--gitbase-user", help="Gitbase user.", type=str, default="root", dest="user"
     )
     preprocess_parser.add_argument(
-        "--gitbase-pass", help="Gitbase password.", type=str, default=""
+        "--gitbase-pass",
+        help="Gitbase password.",
+        type=str,
+        default="",
+        dest="password",
     )
     preprocess_parser.add_argument(
         "--bblfsh-container",

--- a/tmexp/__main__.py
+++ b/tmexp/__main__.py
@@ -3,8 +3,8 @@ import logging
 from typing import Any
 
 from .create_bow import create_bow, DIFF_MODEL, HALL_MODEL
-from .gitbase_constants import COMMENTS, IDENTIFIERS, LITERALS, SUPPORTED_LANGUAGES
-from .preprocess import preprocess
+from .preprocess import COMMENTS, IDENTIFIERS, LITERALS, preprocess
+from .utils import SUPPORTED_LANGUAGES
 
 
 def add_lang_args(cmd_parser: argparse.ArgumentParser) -> None:
@@ -118,12 +118,23 @@ def get_parser() -> argparse.ArgumentParser:
         "--gitbase-pass", help="Gitbase password.", type=str, default=""
     )
     preprocess_parser.add_argument(
+        "--bblfsh-container",
+        help="Name of the Babelfish docker container.",
+        type=str,
+        default="tmexp_bblfshd",
+    )
+    preprocess_parser.add_argument(
         "--bblfsh-host", help="Babelfish hostname.", type=str, default="0.0.0.0"
     )
     preprocess_parser.add_argument(
         "--bblfsh-port", help="Babelfish port.", type=int, default=9432
     )
-
+    preprocess_parser.add_argument(
+        "--bblfsh-timeout",
+        help="Timeout for parse requests made to Babelfish.",
+        type=float,
+        default=10.0,
+    )
     # ------------------------------------------------------------------------
 
     create_bow_parser = subparsers.add_parser(

--- a/tmexp/__main__.py
+++ b/tmexp/__main__.py
@@ -173,15 +173,15 @@ def get_parser() -> argparse.ArgumentParser:
     )
     create_bow_parser.add_argument(
         "--min-word-frac",
-        help="Words occuring in less then this percentage of all documents are removed,"
-        " default to 2 %.",
+        help="Words occuring in less then this draction of all documents are removed,"
+        " defaults to %(default)s.",
         type=float,
         default=0.02,
     )
     create_bow_parser.add_argument(
         "--max-word-frac",
-        help="Words occuring in more then this percentage of all documents are removed,"
-        " default to 80 %.",
+        help="Words occuring in more then this fraction of all documents are removed,"
+        " defaults to %(default)s.",
         type=float,
         default=0.8,
     )

--- a/tmexp/create_bow.py
+++ b/tmexp/create_bow.py
@@ -47,7 +47,7 @@ def create_bow(
     check_exists(input_path)
     if dataset_name is None:
         dataset_name = topic_model
-        output_dir = os.path.join(output_dir, dataset_name)
+    output_dir = os.path.join(output_dir, dataset_name)
     create_directory(output_dir, logger)
     words_output_path = os.path.join(output_dir, VOCAB_FILE_NAME)
     check_remove_file(words_output_path, logger, force)

--- a/tmexp/create_bow.py
+++ b/tmexp/create_bow.py
@@ -1,8 +1,7 @@
 from collections import Counter, defaultdict
-import logging
 import os
 import pickle
-from typing import Any, DefaultDict, Dict, List, Optional, Set
+from typing import Any, Counter as CounterType, DefaultDict, Dict, List, Optional, Set
 
 import tqdm
 
@@ -11,7 +10,7 @@ from .utils import (
     check_remove_file,
     create_directory,
     create_language_list,
-    WordCount,
+    create_logger,
 )
 
 DIFF_MODEL = "diff"
@@ -43,9 +42,7 @@ def create_bow(
     max_word_frac: float,
     log_level: str,
 ) -> None:
-    logger = logging.getLogger(__name__)
-    logger.addHandler(logging.StreamHandler())
-    logger.setLevel(log_level)
+    logger = create_logger(log_level, __name__)
 
     check_exists(input_path)
     if dataset_name is None:
@@ -76,7 +73,7 @@ def create_bow(
         previous_docs: List[str] = []
         previous_blobs: Set[str] = set()
         if topic_model == DIFF_MODEL:
-            previous_count: WordCount = Counter()
+            previous_count: CounterType = Counter()
             doc_added = file_path + SEP + "added"
             doc_deleted = file_path + SEP + "removed"
         for ref in input_dict["refs"]:
@@ -104,7 +101,7 @@ def create_bow(
                     previous_blobs.add(blob_hash)
                     num_blobs += 1
                 blob = blobs[blob_hash]
-                word_counts: WordCount = Counter()
+                word_counts: CounterType = Counter()
                 for feature in features:
                     if feature not in blob:
                         continue

--- a/tmexp/gitbase_queries.py
+++ b/tmexp/gitbase_queries.py
@@ -33,43 +33,5 @@ FROM repositories r
 WHERE r.repository_id = '%s'
     AND is_tag(rf.ref_name)
     AND rf.ref_name in (%s)
-    AND lang in (%s)
+    AND lang in (%s);
 """
-
-IDENTIFIERS = "identifiers"
-LITERALS = "literals"
-COMMENTS = "comments"
-
-IDENTIFIER_XPATH = "//uast:Identifier"
-LITERAL_XPATH = "//uast:String"
-COMMENT_XPATH = "//uast:Comment"
-
-IDENTIFIER_KEY = "Name"
-LITERAL_KEY = "Value"
-COMMENT_KEY = "Text"
-
-FEATURE_MAPPING = {
-    IDENTIFIERS: {"xpath": IDENTIFIER_XPATH, "key": IDENTIFIER_KEY},
-    LITERALS: {"xpath": LITERAL_XPATH, "key": LITERAL_KEY},
-    COMMENTS: {"xpath": COMMENT_XPATH, "key": COMMENT_KEY},
-}
-
-SUPPORTED_LANGUAGES = [
-    "C#",
-    "C++",
-    "C",
-    "Cuda",
-    "OpenCL",
-    "Metal",
-    "Bash",
-    "Shell",
-    "Go",
-    "Java",
-    "JavaScript",
-    "JS",
-    "JSX",
-    "PHP",
-    "Python",
-    "Ruby",
-    "TypeScript",
-]

--- a/tmexp/utils.py
+++ b/tmexp/utils.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 
 import tqdm
 
+# TODO: stop hardcoding when https://github.com/bblfsh/client-python/issues/168 is done
 SUPPORTED_LANGUAGES = [
     "C#",
     "C++",

--- a/tmexp/utils.py
+++ b/tmexp/utils.py
@@ -1,10 +1,51 @@
-from logging import Logger
+import logging
+from logging import Handler, Logger, LogRecord, NOTSET
 import os
-from typing import Counter, List, Optional
+from typing import List, Optional
 
-from .gitbase_constants import SUPPORTED_LANGUAGES
+import tqdm
 
-WordCount = Counter[str]
+SUPPORTED_LANGUAGES = [
+    "C#",
+    "C++",
+    "C",
+    "Cuda",
+    "OpenCL",
+    "Metal",
+    "Bash",
+    "Shell",
+    "Go",
+    "Java",
+    "JavaScript",
+    "JS",
+    "JSX",
+    "PHP",
+    "Python",
+    "Ruby",
+    "TypeScript",
+]
+
+
+class TqdmLoggingHandler(Handler):
+    def __init__(self, level: int = NOTSET) -> None:
+        super().__init__(level)
+
+    def emit(self, record: LogRecord) -> None:
+        try:
+            msg = self.format(record)
+            tqdm.tqdm.write(msg)
+            self.flush()
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except Exception:
+            self.handleError(record)
+
+
+def create_logger(log_level: str, name: str) -> Logger:
+    logger = logging.getLogger(name)
+    logger.setLevel(log_level)
+    logger.addHandler(TqdmLoggingHandler())
+    return logger
 
 
 def check_exists(file_path: str) -> None:


### PR DESCRIPTION
**First commit:**

Renamed `gitbase_constants` to `gitbase_queries` and removed all the constants that were not queries. I did this because these other constants were not used by multiple files anymore, and the only reason we have this file is because it's better aesthetically, not as a global constants file.

**Second commit:**  

Added language constant to utils, as well as one helper that create the logger, and one helper to handle tqdm stream. This way, when we log something while a tqdm progress bar is up, it will not be ugly. I also propagated the changes to the `creaate_bow` file.

**Third commit** 

I added two new arguments to the preprocess command, the value of the timeout for babelfish, as well as the name of the docker container. Both are used to catch the timeout error we talked about. If we see it, then the docker instance is restarted, then after 10s we try to parse the file again. Hopefully we will soon have [this](https://github.com/bblfsh/bblfshd/issues), and will not have to care about this anymore.

In order to circumvent the OOM problem the client has ([issue here](https://github.com/bblfsh/client-python/issues/167) I also added a custom function to replace the call to `filter`, which given a UAST will traverse it, and return a generator with all of the features. This works faster, and does not create mallocated items. While we don't get rid of the OOM problem entirely as the `ResultContext` is never deallocated, it is negligible in comparison. This led me to also move the constants used with Babelfish in the `preprocess` file.
