### PR TITLE
Add HDP train pipeline

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,13 @@ setup(
     url="https://github.com/src-d/tm-experiments",
     packages=find_packages(exclude=["tests"]),
     entry_points={"console_scripts": ["tmexp=tmexp.__main__:main"]},
-    install_requires=["nltk==3.4.3", "pymysql==0.9.3", "bblfsh==3.0.4", "tqdm==4.32.2"],
+    install_requires=[
+        "nltk==3.4.3",
+        "pymysql==0.9.3",
+        "bblfsh==3.0.4",
+        "tqdm==4.32.2",
+        "gensim==3.7.3",
+    ],
     include_package_data=True,
     license="Apache-2.0",
     classifiers=[

--- a/tmexp/create_bow.py
+++ b/tmexp/create_bow.py
@@ -32,7 +32,7 @@ def check_fraction(fraction: float, arg_name: str) -> None:
 def create_bow(
     input_path: str,
     output_dir: str,
-    dataset_name: Optional[str],
+    dataset_name: str,
     langs: Optional[List[str]],
     exclude_langs: Optional[List[str]],
     features: List[str],
@@ -45,8 +45,6 @@ def create_bow(
     logger = create_logger(log_level, __name__)
 
     check_exists(input_path)
-    if dataset_name is None:
-        dataset_name = topic_model
     output_dir = os.path.join(output_dir, dataset_name)
     create_directory(output_dir, logger)
     words_output_path = os.path.join(output_dir, VOCAB_FILE_NAME)

--- a/tmexp/create_bow.py
+++ b/tmexp/create_bow.py
@@ -166,14 +166,14 @@ def create_bow(
     num_words = len(word_index)
     logger.info("Number of distinct words: %d" % num_words)
     logger.info("Saving word index ...")
-    with open(words_output_path, "w") as fout:
+    with open(words_output_path, "w", encoding="utf-8") as fout:
         fout.write("%s\n" % "\n".join(sorted_vocabulary))
     logger.info("Saved word index in '%s'" % words_output_path)
 
     logger.info("Creating and saving document index ...")
     document_index = {}
     num_docs = 0
-    with open(doc_output_path, "w") as fout:
+    with open(doc_output_path, "w", encoding="utf-8") as fout:
         for doc in sorted(docs):
             for i, refs in enumerate(docs[doc]):
                 doc_name = doc + SEP + str(i)
@@ -190,7 +190,7 @@ def create_bow(
         % (num_nnz / (num_docs * num_words))
     )
     logger.info("Saving bags of words ...")
-    with open(docword_output_path, "w") as fout:
+    with open(docword_output_path, "w", encoding="utf-8") as fout:
         for count in [num_docs, num_words, num_nnz]:
             fout.write("%d\n" % count)
         for doc in sorted(docs):

--- a/tmexp/train_hdp.py
+++ b/tmexp/train_hdp.py
@@ -1,5 +1,5 @@
 import os
-from typing import Dict, List, Tuple
+from typing import Dict, List, Set, Tuple
 
 import gensim
 import numpy as np
@@ -46,22 +46,22 @@ def train_hdp(
     create_directory(output_dir, logger)
 
     logger.info("Loading bags of words ...")
-    with open(docword_input_path, "r") as fin:
+    with open(docword_input_path, "r", encoding="utf-8") as fin:
         corpus: List[List[Tuple[int, int]]] = [[] for _ in range(int(fin.readline()))]
         logger.info("Number of documents: %d", len(corpus))
         num_words = int(fin.readline())
         logger.info("Number of words: %d", num_words)
         num_rows = int(fin.readline())
         logger.info("Number of document/word pairs: %d", num_rows)
-        for line in tqdm.tqdm(fin.readlines(), total=num_rows):
-            doc_id, word_id, count = line.split()
-            corpus[int(doc_id)].append((int(word_id), int(count)))
+        for line in tqdm.tqdm(fin, total=num_rows):
+            doc_id, word_id, count = map(int, line.split())
+            corpus[doc_id].append((word_id, count))
     logger.info("Corpus created.")
 
     logger.info("Loading vocabulary ...")
-    with open(words_input_path, "r") as fin:
+    with open(words_input_path, "r", encoding="utf-8") as fin:
         word_index: Dict[int, str] = {
-            i: word.replace("\n", "") for i, word in enumerate(fin.readlines())
+            i: word.replace("\n", "") for i, word in enumerate(fin)
         }
     id2word = gensim.corpora.Dictionary.from_corpus(corpus, word_index)
     logger.info("Word index created.")
@@ -87,8 +87,9 @@ def train_hdp(
         "Inferring topics per document (pruning topics with probability"
         " inferior to %.2f)..." % min_proba
     )
-    num_topics = []
-    document_topics = []
+    num_topics: List[int] = []
+    document_topics: List[List[Tuple[int, float]]] = []
+    used_topics: Set[int] = set()
     for bow in tqdm.tqdm(corpus):
         gammas = hdp.inference([bow])[0]
         topic_dist = gammas / sum(gammas)
@@ -97,13 +98,12 @@ def train_hdp(
             for topic_id, topic_proba in enumerate(topic_dist)
             if topic_proba >= min_proba
         ]
+        used_topics.update(topic_id for topic_id, _ in topics)
         num_topics.append(len(topics))
         topics.sort(key=lambda pair: pair[1], reverse=True)
-        document_topics.append(
-            " ".join(
-                "%d,%f" % (topic_id, topic_proba) for topic_id, topic_proba in topics
-            )
-        )
+        document_topics.append(topics)
+    logger.info("%d topics remain after pruning." % len(used_topics))
+    topic_mapping = {old: new for new, old in enumerate(sorted(used_topics))}
     for op, info in zip(
         [np.min, np.median, np.mean, np.max], ["Minimum", "Median", "Mean", "Maximum"]
     ):
@@ -111,10 +111,17 @@ def train_hdp(
             "%s amount of topics per document after pruning: %.2f", info, op(num_topics)
         )
     logger.info("Saving pruned topics per document ...")
-    with open(doctopic_output_path, "w") as fout:
-        fout.write("\n".join(document_topics))
-    logger.info("Saved topics per document in '%s'." % doctopic_output_path)
+    with open(doctopic_output_path, "w", encoding="utf-8") as fout:
+        for topics in document_topics:
+            fout.write(
+                "%s\n"
+                % " ".join(
+                    "%d,%f" % (topic_mapping[topic_id], topic_proba)
+                    for topic_id, topic_proba in topics
+                )
+            )
+    logger.info("Saved pruned topics per document in '%s'." % doctopic_output_path)
 
     logger.info("Saving word/topic distribution ...")
-    np.save(wordtopic_output_path, hdp.get_topics())
-    logger.info("Saved topics per document in '%s'." % wordtopic_output_path)
+    np.save(wordtopic_output_path, hdp.get_topics()[sorted(used_topics), :])
+    logger.info("Saved word/topic distribution in '%s'." % wordtopic_output_path)

--- a/tmexp/train_hdp.py
+++ b/tmexp/train_hdp.py
@@ -1,0 +1,120 @@
+import os
+from typing import Dict, List, Tuple
+
+import gensim
+import numpy as np
+import tqdm
+
+from .create_bow import DOCWORD_FILE_NAME, VOCAB_FILE_NAME
+from .utils import check_exists, check_remove_file, create_directory, create_logger
+
+
+DOCTOPIC_FILE_NAME = "doc.topic.txt"
+WORDTOPIC_FILENAME = "word.topic.npy"
+
+
+def train_hdp(
+    input_dir: str,
+    output_dir: str,
+    dataset_name: str,
+    force: bool,
+    chunk_size: int,
+    kappa: float,
+    tau: float,
+    K: int,
+    T: int,
+    alpha: int,
+    gamma: int,
+    eta: float,
+    scale: float,
+    var_converge: float,
+    min_proba: float,
+    log_level: str,
+) -> None:
+    logger = create_logger(log_level, __name__)
+
+    input_dir = os.path.join(input_dir, dataset_name)
+    output_dir = os.path.join(output_dir, dataset_name)
+    words_input_path = os.path.join(input_dir, VOCAB_FILE_NAME)
+    check_exists(words_input_path)
+    docword_input_path = os.path.join(input_dir, DOCWORD_FILE_NAME)
+    check_exists(docword_input_path)
+    doctopic_output_path = os.path.join(output_dir, DOCTOPIC_FILE_NAME)
+    check_remove_file(doctopic_output_path, logger, force)
+    wordtopic_output_path = os.path.join(output_dir, WORDTOPIC_FILENAME)
+    check_remove_file(wordtopic_output_path, logger, force)
+    create_directory(output_dir, logger)
+
+    logger.info("Loading bags of words ...")
+    with open(docword_input_path, "r") as fin:
+        corpus: List[List[Tuple[int, int]]] = [[] for _ in range(int(fin.readline()))]
+        logger.info("Number of documents: %d", len(corpus))
+        num_words = int(fin.readline())
+        logger.info("Number of words: %d", num_words)
+        num_rows = int(fin.readline())
+        logger.info("Number of document/word pairs: %d", num_rows)
+        for line in tqdm.tqdm(fin.readlines(), total=num_rows):
+            doc_id, word_id, count = line.split()
+            corpus[int(doc_id)].append((int(word_id), int(count)))
+    logger.info("Corpus created.")
+
+    logger.info("Loading vocabulary ...")
+    with open(words_input_path, "r") as fin:
+        word_index: Dict[int, str] = {
+            i: word.replace("\n", "") for i, word in enumerate(fin.readlines())
+        }
+    id2word = gensim.corpora.Dictionary.from_corpus(corpus, word_index)
+    logger.info("Word index created.")
+
+    logger.info("Training HDP model ...")
+    hdp = gensim.models.HdpModel(
+        corpus,
+        id2word,
+        chunksize=chunk_size,
+        kappa=kappa,
+        tau=tau,
+        K=K,
+        T=T,
+        alpha=alpha,
+        gamma=gamma,
+        eta=eta,
+        scale=scale,
+        var_converge=var_converge,
+    )
+    logger.info("Trained the model.")
+
+    logger.info(
+        "Inferring topics per document (pruning topics with probability"
+        " inferior to %.2f)..." % min_proba
+    )
+    num_topics = []
+    document_topics = []
+    for bow in tqdm.tqdm(corpus):
+        gammas = hdp.inference([bow])[0]
+        topic_dist = gammas / sum(gammas)
+        topics = [
+            (topic_id, topic_proba)
+            for topic_id, topic_proba in enumerate(topic_dist)
+            if topic_proba >= min_proba
+        ]
+        num_topics.append(len(topics))
+        topics.sort(key=lambda pair: pair[1], reverse=True)
+        document_topics.append(
+            " ".join(
+                "%d,%f" % (topic_id, topic_proba) for topic_id, topic_proba in topics
+            )
+        )
+    for op, info in zip(
+        [np.min, np.median, np.mean, np.max], ["Minimum", "Median", "Mean", "Maximum"]
+    ):
+        logger.info(
+            "%s amount of topics per document after pruning: %.2f", info, op(num_topics)
+        )
+    logger.info("Saving pruned topics per document ...")
+    with open(doctopic_output_path, "w") as fout:
+        fout.write("\n".join(document_topics))
+    logger.info("Saved topics per document in '%s'." % doctopic_output_path)
+
+    logger.info("Saving word/topic distribution ...")
+    np.save(wordtopic_output_path, hdp.get_topics())
+    logger.info("Saved topics per document in '%s'." % wordtopic_output_path)


### PR DESCRIPTION
In this PR: 

- added gensim to `setup.py`
- modified the `main`
    - added function for the `dataset-name` arg and removed its default value
    - updated help descriptions to reflect link between input/output dir and dataset-name (as we are doing experiments this hierarchical way of saving seems logical). 
    - added the `train_hdp` command
- modified `create_bow` in consequence
- added the train pipeline for HDP, which outputs two files:
    - the word/topic distribution matrix as a npy file (word index is the same as b4)
    -  the topics per document, a txt file with one line per document (indexed as before):
 `topic_id_1, prob_1 topic_id_2, prob_2 ...` 
The topics are sorted by probability, and the topic index correspond to the one in the other file.

