### PR TITLE
Add dockerfile and stuff

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,12 @@ FROM ubuntu:18.04
 
 RUN mkdir /data
 
-ENV FEATURE_DIR=/data/features \
-    BOW_DIR=/data/bow \
-    TOPICS_DIR=/data/topics \
-    VIZ_DIR=/data/visualisations
+ENV BBLFSH_HOSTNAME=tmexp_bblfshd \
+  BBLFSH_PORT=9432 \
+  GITBASE_HOSTNAME=gitbase \
+  GITBASE_PORT=3306 \
+  GITBASE_USERNAME=root \
+  GITBASE_PASSWORD=
 
 RUN apt-get update \
   && apt-get install -y dialog apt-utils curl \
@@ -19,16 +21,18 @@ RUN apt-get update \
   && cd /usr/local/bin \
   && ln -s /usr/bin/python3 python \
   && apt-get remove -y .*-doc .*-man >/dev/null \
-  && apt-get autoremove -y \ 
+  && apt-get autoremove --purge -y \ 
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
 
 COPY requirements.txt package/
+
+RUN pip3 install --no-cache-dir -r package/requirements.txt
+
 COPY setup.py package/
 COPY README.md package/
 COPY tmexp package/tmexp/
 
-RUN pip3 install --no-cache-dir -r package/requirements.txt
 RUN pip3 install --no-cache-dir  package/.
 ENTRYPOINT ["tmexp"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN mkdir /data
 
 ENV BBLFSH_HOSTNAME=tmexp_bblfshd \
   BBLFSH_PORT=9432 \
-  GITBASE_HOSTNAME=gitbase \
+  GITBASE_HOSTNAME=tmexp_gitbase \
   GITBASE_PORT=3306 \
   GITBASE_USERNAME=root \
   GITBASE_PASSWORD=

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM ubuntu:18.04
+
+RUN mkdir /data
+
+ENV FEATURE_DIR=/data/features \
+    BOW_DIR=/data/bow \
+    TOPICS_DIR=/data/topics \
+    VIZ_DIR=/data/visualisations
+
+RUN apt-get update \
+  && apt-get install -y dialog apt-utils curl \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN curl -sSL https://get.docker.com/ | sh 
+
+RUN apt-get update \
+  && apt-get install -y python3-pip python3-dev \
+  && cd /usr/local/bin \
+  && ln -s /usr/bin/python3 python \
+  && apt-get remove -y .*-doc .*-man >/dev/null \
+  && apt-get autoremove -y \ 
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+
+COPY requirements.txt package/
+COPY setup.py package/
+COPY README.md package/
+COPY tmexp package/tmexp/
+
+RUN pip3 install --no-cache-dir -r package/requirements.txt
+RUN pip3 install --no-cache-dir  package/.
+ENTRYPOINT ["tmexp"]

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ gitbase-start:
 			--link $(BBLFSHD_NAME):$(BBLFSHD_NAME) \
 			--env BBLFSH_ENDPOINT=$(BBLFSHD_NAME):$(BBLFSHD_PORT) \
 			--volume $(RESOLVED_REPOS):/opt/repos \
-			srcd/gitbase:v0.21.0;\
+			srcd/gitbase:v0.22.0;\
 	fi
 
 .PHONY: check start bblfsh-start gitbase-start

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BBLFSHD_NAME ?= tmexp_bblfshd
 BBLFSHD_PORT ?= 9432
-GITBASE_NAME ?= gitbase
+GITBASE_NAME ?= tmexp_gitbase
 GITBASE_PORT ?= 3306
 REPOS ?= repos
 RESOLVED_REPOS != readlink --canonicalize-missing $(REPOS)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,58 @@
 # Topic Modeling Experiments on Source Code
+
+## Getting Started
+
+_In the following we do not do so, however it is good practice to limit the amount of memory docker containers have access to with the `-m` flag._
+
+Start by cloning the repository, then building the docker image:
+
+```
+git clone https://github.com/src-d/tm-experiments
+```
+
+You should also create a directory for all the data. In the following, we call this `/path/to/data`, and will be using defaults values provided by the container for inputs/outputs.
+
+### Preprocess
+
+Launch Babelfish, install all drivers and check you can see them:
+
+```
+docker run -d --rm --name tmexp_bblfshd --privileged -p 9432:9432 -v /var/lib/bblfshd:/var/lib/bblfshd bblfsh/bblfshd:latest-drivers
+docker exec -it tmexp_bblfshd bblfshctl driver install --all -f
+docker exec -it tmexp_bblfshd bblfshctl driver list
+```
+
+Clone one or multiple repository in a directory, then launch gitbase:
+
+```
+docker run -d --rm --name gitbase -p 3306:3306 --link tmexp_bblfshd:tmexp_bblfshd -e BBLFSH_ENDPOINT=tmexp_bblfshd:9432 -v /path/to/repos:/opt/repos srcd/gitbase:latest
+```
+
+Finally, launch the preprocessing (we give the docker socket in order to be able to relaunch Babelfish, however this is a temporary hack):
+
+```
+docker run --rm -i -v /var/run/docker.sock:/var/run/docker.sock -v /path/to/data:/data --link tmexp_bblfshd:tmexp_bblfshd --link gitbase:gitbase tmexp preprocess -r repo
+```
+
+Once your job is finished, the output file should be located in `/path/to/data/features/`. Unless you wish to run this command once more, you can remove the Babelfish and Gitbase containers, as they will not be of further use.
+
+### Create BoW
+
+You can launch the bag-of-words creation with:
+
+```
+docker run --rm -i -v /path/to/data:/data tmexp create_bow --topic-model diff --dataset-name dataset
+```
+
+Once your job is finished, the output files should be located in `/path/to/data/bow/dataset/`
+
+### Train HDP
+
+You can launch the training with:
+
+```
+docker run --rm -i -v /path/to/data:/data tmexp train_hdp --dataset-name dataset
+```
+
+Once your job is finished, the output files should be located in `/path/to/data/topics/dataset/experiment_1`. If you want something more verbose, you can also specify the name of your experiement.
+

--- a/README.md
+++ b/README.md
@@ -36,18 +36,18 @@ For all commands we only specify the required arguments, check the optional ones
 This command will allow you to create a dataset from a cloned git repository. Before launching the command, you will thus need to clone one (or multiple) repository in a directory, as well as start the Babelfish and Gitbase servers:
 
 ```
-make start RESOLVED_REPOS=~/path/to/cloned/repos
+make start REPOS=~/path/to/cloned/repos
 ```
 
-You can now launch the preprocessing withe the follow command _(we give the docker socket in order to be able to relaunch Babelfish, however this is a **temporary** hack)_:
+You can now launch the preprocessing with the following command _(we give the docker socket in order to be able to relaunch Babelfish, however this is a **temporary** hack)_:
 
 ```
-docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock -v /path/to/data:/data --link tmexp_bblfshd:tmexp_bblfshd --link gitbase:gitbase tmexp preprocess -r repo --dataset-name my-dataset
+docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock -v /path/to/data:/data --link tmexp_bblfshd:tmexp_bblfshd --link tmexp_gitbase:tmexp_gitbase tmexp preprocess -r repo --dataset-name my-dataset
 ```
 
 Once your job is finished, the output file should be located in `/path/to/data/datasets/`. Unless you wish to run this command once more, you can remove the Babelfish and Gitbase containers, as they will not be of further use, with:
 
-`docker stop gitbase tmexp_bblfshd`
+`docker stop tmexp_gitbase tmexp_bblfshd`
 
 ### Create BoW
 

--- a/README.md
+++ b/README.md
@@ -4,55 +4,67 @@
 
 _In the following we do not do so, however it is good practice to limit the amount of memory docker containers have access to with the `-m` flag._
 
-Start by cloning the repository, then building the docker image:
+Start by cloning the repository, and building the docker image:
 
 ```
 git clone https://github.com/src-d/tm-experiments
+docker build tm-experiments -t tmexp
 ```
 
-You should also create a directory for all the data. In the following, we call this `/path/to/data`, and will be using defaults values provided by the container for inputs/outputs.
+In all of the following, all of the created data will be stored in a single directory (hereinafter referred to as `/path/to/data`), which would have the following structure if you were to run with the exact same names:
+
+```
+data
+├── datasets
+│   └── my-dataset.pkl
+├── bows
+│   └── my-bow
+│       ├── doc.bow_tm.txt
+│       ├── docword.bow_tm.txt
+│       └── vocab.bow_tm.txt
+└── topics
+    └── my-bow
+        └── my-exp
+            ├── doc.topic.txt
+            └── word.topic.npy
+```
+
+For all commands we only specify the required arguments, check the optional ones with `docker run --rm -i tmexp $CMD --help`
 
 ### Preprocess
 
-Launch Babelfish, install all drivers and check you can see them:
+This command will allow you to create a dataset from a cloned git repository. Before launching the command, you will thus need to clone one (or multiple) repository in a directory, as well as start the Babelfish and Gitbase servers:
 
 ```
-docker run -d --rm --name tmexp_bblfshd --privileged -p 9432:9432 -v /var/lib/bblfshd:/var/lib/bblfshd bblfsh/bblfshd:latest-drivers
-docker exec -it tmexp_bblfshd bblfshctl driver install --all -f
-docker exec -it tmexp_bblfshd bblfshctl driver list
+make start RESOLVED_REPOS=~/path/to/cloned/repos
 ```
 
-Clone one or multiple repository in a directory, then launch gitbase:
+You can now launch the preprocessing withe the follow command _(we give the docker socket in order to be able to relaunch Babelfish, however this is a **temporary** hack)_:
 
 ```
-docker run -d --rm --name gitbase -p 3306:3306 --link tmexp_bblfshd:tmexp_bblfshd -e BBLFSH_ENDPOINT=tmexp_bblfshd:9432 -v /path/to/repos:/opt/repos srcd/gitbase:latest
+docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock -v /path/to/data:/data --link tmexp_bblfshd:tmexp_bblfshd --link gitbase:gitbase tmexp preprocess -r repo --dataset-name my-dataset
 ```
 
-Finally, launch the preprocessing (we give the docker socket in order to be able to relaunch Babelfish, however this is a temporary hack):
+Once your job is finished, the output file should be located in `/path/to/data/datasets/`. Unless you wish to run this command once more, you can remove the Babelfish and Gitbase containers, as they will not be of further use, with:
 
-```
-docker run --rm -i -v /var/run/docker.sock:/var/run/docker.sock -v /path/to/data:/data --link tmexp_bblfshd:tmexp_bblfshd --link gitbase:gitbase tmexp preprocess -r repo
-```
-
-Once your job is finished, the output file should be located in `/path/to/data/features/`. Unless you wish to run this command once more, you can remove the Babelfish and Gitbase containers, as they will not be of further use.
+`docker stop gitbase tmexp_bblfshd`
 
 ### Create BoW
 
-You can launch the bag-of-words creation with:
+You can launch the bag-of-words creation with the following command (don't forget to specify the dataset name):
 
 ```
-docker run --rm -i -v /path/to/data:/data tmexp create_bow --topic-model diff --dataset-name dataset
+docker run --rm -it -v /path/to/data:/data tmexp create_bow --topic-model diff --dataset-name my-dataset --bow-name my-bow
 ```
 
-Once your job is finished, the output files should be located in `/path/to/data/bow/dataset/`
+Once your job is finished, the output files should be located in `/path/to/data/bows/my-bow/`
 
 ### Train HDP
 
-You can launch the training with:
+You can launch the training with the following command (don't forget to specify the bow name):
 
 ```
-docker run --rm -i -v /path/to/data:/data tmexp train_hdp --dataset-name dataset
+docker run --rm -it -v /path/to/data:/data tmexp train_hdp --bow-name my-bow --exp-name my-exp
 ```
 
-Once your job is finished, the output files should be located in `/path/to/data/topics/dataset/experiment_1`. If you want something more verbose, you can also specify the name of your experiement.
-
+Once your job is finished, the output files should be located in `/path/to/data/topics/my-bow/my-exp`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+nltk==3.4.3
+pymysql==0.9.3
+bblfsh==3.0.4
+tqdm==4.32.2
+gensim==3.7.3

--- a/tmexp/__main__.py
+++ b/tmexp/__main__.py
@@ -47,9 +47,30 @@ def add_force_arg(cmd_parser: argparse.ArgumentParser) -> None:
 def add_dataset_arg(cmd_parser: argparse.ArgumentParser) -> None:
     cmd_parser.add_argument(
         "--dataset-name",
-        help="Name of the dataset, used as the second level input/output directory.",
+        help="Name of the dataset created by `preprocess`, defaults"
+        " to 'MM-DD-HH:MM-dataset'.",
+        default=None,
         type=str,
-        required=True,
+    )
+
+
+def add_bow_arg(cmd_parser: argparse.ArgumentParser) -> None:
+    cmd_parser.add_argument(
+        "--bow-name",
+        help="Name of the BoW created by `create_bow`, defaults"
+        " to 'MM-DD-HH:MM-bow'.",
+        default=None,
+        type=str,
+    )
+
+
+def add_experiment_arg(cmd_parser: argparse.ArgumentParser) -> None:
+    cmd_parser.add_argument(
+        "--exp-name",
+        help="Name of the experiment created by `train_$`, defaults"
+        " to 'MM-DD-HH:MM-experiment'.",
+        default=None,
+        type=str,
     )
 
 
@@ -75,9 +96,12 @@ def get_parser() -> argparse.ArgumentParser:
         "repository and store them as a pickled dict.",
     )
     preprocess_parser.set_defaults(handler=preprocess)
-    add_lang_args(preprocess_parser)
+
+    add_dataset_arg(preprocess_parser)
     add_feature_arg(preprocess_parser)
     add_force_arg(preprocess_parser)
+    add_lang_args(preprocess_parser)
+
     preprocess_parser.add_argument(
         "-r", "--repo", help="Name of the repo to preprocess.", type=str, required=True
     )
@@ -100,13 +124,6 @@ def get_parser() -> argparse.ArgumentParser:
         default=".",
     )
     preprocess_parser.add_argument(
-        "-o",
-        "--output-path",
-        help="Output path for the pickled dict, defaults to FEATURE_DIR/features.pkl.",
-        type=str,
-        default=None,
-    )
-    preprocess_parser.add_argument(
         "--no-tokenize",
         help="To skip tokenization.",
         dest="tokenize",
@@ -114,32 +131,6 @@ def get_parser() -> argparse.ArgumentParser:
     )
     preprocess_parser.add_argument(
         "--no-stem", help="To skip stemming.", dest="stem", action="store_false"
-    )
-    preprocess_parser.add_argument(
-        "--gitbase-host",
-        help="Gitbase hostname.",
-        type=str,
-        default="gitbase",
-        dest="host",
-    )
-    preprocess_parser.add_argument(
-        "--gitbase-port", help="Gitbase port.", type=int, default=3306, dest="port"
-    )
-    preprocess_parser.add_argument(
-        "--gitbase-user", help="Gitbase user.", type=str, default="root", dest="user"
-    )
-    preprocess_parser.add_argument(
-        "--gitbase-pass",
-        help="Gitbase password.",
-        type=str,
-        default="",
-        dest="password",
-    )
-    preprocess_parser.add_argument(
-        "--bblfsh-host", help="Babelfish hostname.", type=str, default="tmexp_bblfshd"
-    )
-    preprocess_parser.add_argument(
-        "--bblfsh-port", help="Babelfish port.", type=int, default=9432
     )
     preprocess_parser.add_argument(
         "--bblfsh-timeout",
@@ -153,24 +144,13 @@ def get_parser() -> argparse.ArgumentParser:
         "create_bow", help="Create the BoW dataset from a pickled dict, in UCI format."
     )
     create_bow_parser.set_defaults(handler=create_bow)
-    add_lang_args(create_bow_parser)
+
+    add_bow_arg(create_bow_parser)
+    add_dataset_arg(create_bow_parser)
     add_feature_arg(create_bow_parser)
     add_force_arg(create_bow_parser)
-    add_dataset_arg(create_bow_parser)
-    create_bow_parser.add_argument(
-        "-i",
-        "--input-path",
-        help="Input path for the pickled dict, defaults to FEATURE_DIR/features.pkl.",
-        type=str,
-        default=None,
-    )
-    create_bow_parser.add_argument(
-        "-o",
-        "--output-dir",
-        help="First level output directory for the BoW files, defaults to BOW_DIR.",
-        type=str,
-        default=None,
-    )
+    add_lang_args(create_bow_parser)
+
     create_bow_parser.add_argument(
         "--topic-model",
         help="Topic evolution model to use.",
@@ -198,30 +178,11 @@ def get_parser() -> argparse.ArgumentParser:
         "train_hdp", help="Train an HDP model from the input BoW."
     )
     train_hdp_parser.set_defaults(handler=train_hdp)
+
+    add_bow_arg(train_hdp_parser)
+    add_experiment_arg(train_hdp_parser)
     add_force_arg(train_hdp_parser)
-    add_dataset_arg(train_hdp_parser)
-    train_hdp_parser.add_argument(
-        "-i",
-        "--input-dir",
-        help="First level input directory for the BoW files, defaults to BOW_DIR.",
-        default=None,
-        type=str,
-    )
-    train_hdp_parser.add_argument(
-        "-o",
-        "--output-dir",
-        help="First level output directory for the word-topic and document-topic"
-        " distributions, defaults to TOPIC_DIR.",
-        default=None,
-        type=str,
-    )
-    train_hdp_parser.add_argument(
-        "--exp-name",
-        help="Name of the experiment, defaults to 'experiment_i' where i is the number "
-        "of other experiments for this dataset.",
-        default=None,
-        type=str,
-    )
+
     train_hdp_parser.add_argument(
         "--chunk-size", help="Number of documents in one chunk.", default=256, type=int
     )

--- a/tmexp/__main__.py
+++ b/tmexp/__main__.py
@@ -102,9 +102,9 @@ def get_parser() -> argparse.ArgumentParser:
     preprocess_parser.add_argument(
         "-o",
         "--output-path",
-        help="Output path for the pickled dict.",
-        required=True,
+        help="Output path for the pickled dict, defaults to FEATURE_DIR/features.pkl.",
         type=str,
+        default=None,
     )
     preprocess_parser.add_argument(
         "--no-tokenize",
@@ -119,7 +119,7 @@ def get_parser() -> argparse.ArgumentParser:
         "--gitbase-host",
         help="Gitbase hostname.",
         type=str,
-        default="0.0.0.0",
+        default="gitbase",
         dest="host",
     )
     preprocess_parser.add_argument(
@@ -136,13 +136,7 @@ def get_parser() -> argparse.ArgumentParser:
         dest="password",
     )
     preprocess_parser.add_argument(
-        "--bblfsh-container",
-        help="Name of the Babelfish docker container.",
-        type=str,
-        default="tmexp_bblfshd",
-    )
-    preprocess_parser.add_argument(
-        "--bblfsh-host", help="Babelfish hostname.", type=str, default="0.0.0.0"
+        "--bblfsh-host", help="Babelfish hostname.", type=str, default="tmexp_bblfshd"
     )
     preprocess_parser.add_argument(
         "--bblfsh-port", help="Babelfish port.", type=int, default=9432
@@ -166,16 +160,16 @@ def get_parser() -> argparse.ArgumentParser:
     create_bow_parser.add_argument(
         "-i",
         "--input-path",
-        help="Input path for the pickled dict.",
-        required=True,
+        help="Input path for the pickled dict, defaults to FEATURE_DIR/features.pkl.",
         type=str,
+        default=None,
     )
     create_bow_parser.add_argument(
         "-o",
         "--output-dir",
-        help="First level output directory for the BoW files.",
-        required=True,
+        help="First level output directory for the BoW files, defaults to BOW_DIR.",
         type=str,
+        default=None,
     )
     create_bow_parser.add_argument(
         "--topic-model",
@@ -209,16 +203,23 @@ def get_parser() -> argparse.ArgumentParser:
     train_hdp_parser.add_argument(
         "-i",
         "--input-dir",
-        help="First level input directory for the BoW files.",
-        required=True,
+        help="First level input directory for the BoW files, defaults to BOW_DIR.",
+        default=None,
         type=str,
     )
     train_hdp_parser.add_argument(
         "-o",
         "--output-dir",
         help="First level output directory for the word-topic and document-topic"
-        " distributions.",
-        required=True,
+        " distributions, defaults to TOPIC_DIR.",
+        default=None,
+        type=str,
+    )
+    train_hdp_parser.add_argument(
+        "--exp-name",
+        help="Name of the experiment, defaults to 'experiment_i' where i is the number "
+        "of other experiments for this dataset.",
+        default=None,
         type=str,
     )
     train_hdp_parser.add_argument(

--- a/tmexp/create_bow.py
+++ b/tmexp/create_bow.py
@@ -6,11 +6,15 @@ from typing import Any, Counter as CounterType, DefaultDict, Dict, List, Optiona
 import tqdm
 
 from .utils import (
-    check_exists,
+    BOW_DIR,
+    check_env_exists,
+    check_file_exists,
     check_remove_file,
     create_directory,
     create_language_list,
     create_logger,
+    FEATURE_DEFAULT_FILENAME,
+    FEATURE_DIR,
 )
 
 DIFF_MODEL = "diff"
@@ -30,8 +34,8 @@ def check_fraction(fraction: float, arg_name: str) -> None:
 
 
 def create_bow(
-    input_path: str,
-    output_dir: str,
+    input_path: Optional[str],
+    output_dir: Optional[str],
     dataset_name: str,
     langs: Optional[List[str]],
     exclude_langs: Optional[List[str]],
@@ -44,7 +48,14 @@ def create_bow(
 ) -> None:
     logger = create_logger(log_level, __name__)
 
-    check_exists(input_path)
+    if input_path is None:
+        input_path = check_env_exists(FEATURE_DIR, "input-path")
+        input_path = os.path.join(input_path, FEATURE_DEFAULT_FILENAME)
+        logger.info("Using default filename for input.")
+    check_file_exists(input_path)
+
+    if output_dir is None:
+        output_dir = check_env_exists(BOW_DIR, "output-dir")
     output_dir = os.path.join(output_dir, dataset_name)
     create_directory(output_dir, logger)
     words_output_path = os.path.join(output_dir, VOCAB_FILE_NAME)
@@ -53,6 +64,7 @@ def create_bow(
     check_remove_file(docword_output_path, logger, force)
     doc_output_path = os.path.join(output_dir, DOC_FILE_NAME)
     check_remove_file(doc_output_path, logger, force)
+
     check_fraction(min_word_frac, "min-word-frac")
     check_fraction(max_word_frac, "max-word-frac")
 

--- a/tmexp/create_bow.py
+++ b/tmexp/create_bow.py
@@ -7,23 +7,21 @@ import tqdm
 
 from .utils import (
     BOW_DIR,
-    check_env_exists,
+    check_create_default,
     check_file_exists,
     check_remove_file,
     create_directory,
     create_language_list,
     create_logger,
-    FEATURE_DEFAULT_FILENAME,
-    FEATURE_DIR,
+    DATASET_DIR,
+    DOC_FILE_NAME,
+    DOCWORD_FILE_NAME,
+    VOCAB_FILE_NAME,
 )
 
 DIFF_MODEL = "diff"
 HALL_MODEL = "hall"
 SEP = ":"
-
-DOC_FILE_NAME = "doc.bow_tm.txt"
-DOCWORD_FILE_NAME = "docword.bow_tm.txt"
-VOCAB_FILE_NAME = "vocab.bow_tm.txt"
 
 
 def check_fraction(fraction: float, arg_name: str) -> None:
@@ -34,9 +32,8 @@ def check_fraction(fraction: float, arg_name: str) -> None:
 
 
 def create_bow(
-    input_path: Optional[str],
-    output_dir: Optional[str],
-    dataset_name: str,
+    dataset_name: Optional[str],
+    bow_name: Optional[str],
     langs: Optional[List[str]],
     exclude_langs: Optional[List[str]],
     features: List[str],
@@ -48,15 +45,13 @@ def create_bow(
 ) -> None:
     logger = create_logger(log_level, __name__)
 
-    if input_path is None:
-        input_path = check_env_exists(FEATURE_DIR, "input-path")
-        input_path = os.path.join(input_path, FEATURE_DEFAULT_FILENAME)
-        logger.info("Using default filename for input.")
+    if dataset_name is None:
+        raise RuntimeError("Dataset name not specified, aborting.")
+    input_path = os.path.join(DATASET_DIR, dataset_name + ".pkl")
     check_file_exists(input_path)
 
-    if output_dir is None:
-        output_dir = check_env_exists(BOW_DIR, "output-dir")
-    output_dir = os.path.join(output_dir, dataset_name)
+    bow_name = check_create_default(bow_name, "bow", logger)
+    output_dir = os.path.join(BOW_DIR, bow_name)
     create_directory(output_dir, logger)
     words_output_path = os.path.join(output_dir, VOCAB_FILE_NAME)
     check_remove_file(words_output_path, logger, force)

--- a/tmexp/create_bow.py
+++ b/tmexp/create_bow.py
@@ -7,7 +7,6 @@ import tqdm
 
 from .utils import (
     BOW_DIR,
-    check_create_default,
     check_file_exists,
     check_remove_file,
     create_directory,
@@ -32,8 +31,8 @@ def check_fraction(fraction: float, arg_name: str) -> None:
 
 
 def create_bow(
-    dataset_name: Optional[str],
-    bow_name: Optional[str],
+    dataset_name: str,
+    bow_name: str,
     langs: Optional[List[str]],
     exclude_langs: Optional[List[str]],
     features: List[str],
@@ -45,12 +44,9 @@ def create_bow(
 ) -> None:
     logger = create_logger(log_level, __name__)
 
-    if dataset_name is None:
-        raise RuntimeError("Dataset name not specified, aborting.")
     input_path = os.path.join(DATASET_DIR, dataset_name + ".pkl")
     check_file_exists(input_path)
 
-    bow_name = check_create_default(bow_name, "bow", logger)
     output_dir = os.path.join(BOW_DIR, bow_name)
     create_directory(output_dir, logger)
     words_output_path = os.path.join(output_dir, VOCAB_FILE_NAME)

--- a/tmexp/preprocess.py
+++ b/tmexp/preprocess.py
@@ -25,7 +25,6 @@ import tqdm
 
 from .gitbase_queries import FILE_CONTENT, FILE_INFO, TAGGED_REFS
 from .utils import (
-    check_create_default,
     check_env_exists,
     check_remove_file,
     create_directory,
@@ -94,7 +93,7 @@ def extract(
 
 def preprocess(
     repo: str,
-    dataset_name: Optional[str],
+    dataset_name: str,
     exclude_refs: List[str],
     only_by_date: bool,
     version_sep: str,
@@ -122,14 +121,12 @@ def preprocess(
 
     logger = create_logger(log_level, __name__)
 
-    dataset_name = check_create_default(dataset_name, "dataset", logger)
-
     output_path = os.path.join(DATASET_DIR, dataset_name + ".pkl")
     check_remove_file(output_path, logger, force)
     create_directory(os.path.dirname(output_path), logger)
 
     bblfsh_host = check_env_exists("BBLFSH_HOSTNAME")
-    bblfsh_port = check_env_exists("BBLFSH_PORT")
+    bblfsh_port = int(check_env_exists("BBLFSH_PORT"))
     host = check_env_exists("GITBASE_HOSTNAME")
     port = int(check_env_exists("GITBASE_PORT"))
     user = check_env_exists("GITBASE_USERNAME")
@@ -192,7 +189,7 @@ def preprocess(
     if stem:
         stemmer = PorterStemmer()
     blacklisted_files: Set[str] = set()
-    client = bblfsh.BblfshClient("%s:%s" % (bblfsh_host, bblfsh_port))
+    client = bblfsh.BblfshClient("%s:%d" % (bblfsh_host, bblfsh_port))
     parsed_count: CounterType = Counter()
     feature_mapping = {
         xpath: feature_tuple

--- a/tmexp/train_hdp.py
+++ b/tmexp/train_hdp.py
@@ -5,26 +5,23 @@ import gensim
 import numpy as np
 import tqdm
 
-from .create_bow import DOCWORD_FILE_NAME, VOCAB_FILE_NAME
 from .utils import (
     BOW_DIR,
-    check_env_exists,
+    check_create_default,
     check_file_exists,
     check_remove_file,
     create_directory,
     create_logger,
+    DOCTOPIC_FILE_NAME,
+    DOCWORD_FILE_NAME,
     TOPICS_DIR,
+    VOCAB_FILE_NAME,
+    WORDTOPIC_FILENAME,
 )
 
 
-DOCTOPIC_FILE_NAME = "doc.topic.txt"
-WORDTOPIC_FILENAME = "word.topic.npy"
-
-
 def train_hdp(
-    input_dir: Optional[str],
-    output_dir: Optional[str],
-    dataset_name: str,
+    bow_name: Optional[str],
     exp_name: Optional[str],
     force: bool,
     chunk_size: int,
@@ -42,20 +39,16 @@ def train_hdp(
 ) -> None:
     logger = create_logger(log_level, __name__)
 
-    if input_dir is None:
-        input_dir = check_env_exists(BOW_DIR, "input-dir")
-    input_dir = os.path.join(input_dir, dataset_name)
+    if bow_name is None:
+        raise RuntimeError("Bow name not specified, aborting.")
+    input_dir = os.path.join(BOW_DIR, bow_name)
     words_input_path = os.path.join(input_dir, VOCAB_FILE_NAME)
     check_file_exists(words_input_path)
     docword_input_path = os.path.join(input_dir, DOCWORD_FILE_NAME)
     check_file_exists(docword_input_path)
 
-    if output_dir is None:
-        output_dir = check_env_exists(TOPICS_DIR, "output-dir")
-    output_dir = os.path.join(output_dir, dataset_name)
-    if exp_name is None:
-        exp_name = "experiment_%d" % (len(os.listdir(output_dir)) + 1)
-    output_dir = os.path.join(output_dir, exp_name)
+    exp_name = check_create_default(exp_name, "experiment", logger)
+    output_dir = os.path.join(TOPICS_DIR, bow_name, exp_name)
     doctopic_output_path = os.path.join(output_dir, DOCTOPIC_FILE_NAME)
     check_remove_file(doctopic_output_path, logger, force)
     wordtopic_output_path = os.path.join(output_dir, WORDTOPIC_FILENAME)

--- a/tmexp/train_hdp.py
+++ b/tmexp/train_hdp.py
@@ -1,5 +1,5 @@
 import os
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Dict, List, Set, Tuple
 
 import gensim
 import numpy as np
@@ -7,7 +7,6 @@ import tqdm
 
 from .utils import (
     BOW_DIR,
-    check_create_default,
     check_file_exists,
     check_remove_file,
     create_directory,
@@ -21,8 +20,8 @@ from .utils import (
 
 
 def train_hdp(
-    bow_name: Optional[str],
-    exp_name: Optional[str],
+    bow_name: str,
+    exp_name: str,
     force: bool,
     chunk_size: int,
     kappa: float,
@@ -39,15 +38,12 @@ def train_hdp(
 ) -> None:
     logger = create_logger(log_level, __name__)
 
-    if bow_name is None:
-        raise RuntimeError("Bow name not specified, aborting.")
     input_dir = os.path.join(BOW_DIR, bow_name)
     words_input_path = os.path.join(input_dir, VOCAB_FILE_NAME)
     check_file_exists(words_input_path)
     docword_input_path = os.path.join(input_dir, DOCWORD_FILE_NAME)
     check_file_exists(docword_input_path)
 
-    exp_name = check_create_default(exp_name, "experiment", logger)
     output_dir = os.path.join(TOPICS_DIR, bow_name, exp_name)
     doctopic_output_path = os.path.join(output_dir, DOCTOPIC_FILE_NAME)
     check_remove_file(doctopic_output_path, logger, force)

--- a/tmexp/train_hdp.py
+++ b/tmexp/train_hdp.py
@@ -1,12 +1,20 @@
 import os
-from typing import Dict, List, Set, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
 import gensim
 import numpy as np
 import tqdm
 
 from .create_bow import DOCWORD_FILE_NAME, VOCAB_FILE_NAME
-from .utils import check_exists, check_remove_file, create_directory, create_logger
+from .utils import (
+    BOW_DIR,
+    check_env_exists,
+    check_file_exists,
+    check_remove_file,
+    create_directory,
+    create_logger,
+    TOPICS_DIR,
+)
 
 
 DOCTOPIC_FILE_NAME = "doc.topic.txt"
@@ -14,9 +22,10 @@ WORDTOPIC_FILENAME = "word.topic.npy"
 
 
 def train_hdp(
-    input_dir: str,
-    output_dir: str,
+    input_dir: Optional[str],
+    output_dir: Optional[str],
     dataset_name: str,
+    exp_name: Optional[str],
     force: bool,
     chunk_size: int,
     kappa: float,
@@ -33,12 +42,20 @@ def train_hdp(
 ) -> None:
     logger = create_logger(log_level, __name__)
 
+    if input_dir is None:
+        input_dir = check_env_exists(BOW_DIR, "input-dir")
     input_dir = os.path.join(input_dir, dataset_name)
-    output_dir = os.path.join(output_dir, dataset_name)
     words_input_path = os.path.join(input_dir, VOCAB_FILE_NAME)
-    check_exists(words_input_path)
+    check_file_exists(words_input_path)
     docword_input_path = os.path.join(input_dir, DOCWORD_FILE_NAME)
-    check_exists(docword_input_path)
+    check_file_exists(docword_input_path)
+
+    if output_dir is None:
+        output_dir = check_env_exists(TOPICS_DIR, "output-dir")
+    output_dir = os.path.join(output_dir, dataset_name)
+    if exp_name is None:
+        exp_name = "experiment_%d" % (len(os.listdir(output_dir)) + 1)
+    output_dir = os.path.join(output_dir, exp_name)
     doctopic_output_path = os.path.join(output_dir, DOCTOPIC_FILE_NAME)
     check_remove_file(doctopic_output_path, logger, force)
     wordtopic_output_path = os.path.join(output_dir, WORDTOPIC_FILENAME)

--- a/tmexp/utils.py
+++ b/tmexp/utils.py
@@ -1,6 +1,7 @@
 import logging
 from logging import Handler, Logger, LogRecord, NOTSET
 import os
+import time
 from typing import List, Optional
 
 import tqdm
@@ -26,11 +27,18 @@ SUPPORTED_LANGUAGES = [
     "TypeScript",
 ]
 
-FEATURE_DIR = "FEATURE_DIR"
-FEATURE_DEFAULT_FILENAME = "features.pkl"
-BOW_DIR = "BOW_DIR"
-TOPICS_DIR = "TOPICS_DIR"
-VIZ_DIR = "VIZ_DIR"
+DATASET_DIR = "/data/datasets"
+
+BOW_DIR = "/data/bows"
+DOC_FILE_NAME = "doc.bow_tm.txt"
+DOCWORD_FILE_NAME = "docword.bow_tm.txt"
+VOCAB_FILE_NAME = "vocab.bow_tm.txt"
+
+TOPICS_DIR = "/data/topics"
+DOCTOPIC_FILE_NAME = "doc.topic.txt"
+WORDTOPIC_FILENAME = "word.topic.npy"
+
+VIZ_DIR = "/data/visualisations"
 
 
 class TqdmLoggingHandler(Handler):
@@ -55,17 +63,21 @@ def create_logger(log_level: str, name: str) -> Logger:
     return logger
 
 
+def check_create_default(name: Optional[str], out_type: str, logger: Logger) -> str:
+    if name is None:
+        name = "%s-%s" % (time.strftime("%m-%d-%H:%M"), out_type)
+        logger.info("Created default %s name: '%s'", out_type, name)
+    return name
+
+
 def check_file_exists(file_path: str) -> None:
     if not os.path.exists(file_path):
-        raise RuntimeError("File '%s' does not exists, aborting." % file_path)
+        raise FileNotFoundError("File '%s' does not exists, aborting." % file_path)
 
 
-def check_env_exists(env_name: str, arg_name: str) -> str:
+def check_env_exists(env_name: str) -> str:
     if env_name not in os.environ:
-        raise RuntimeError(
-            "Variable '%s' does not exists, aborting (either create it or"
-            "specify argument '%s')." % (env_name, arg_name)
-        )
+        raise RuntimeError("Variable '%s' does not exists, aborting." % env_name)
     return os.environ[env_name]
 
 

--- a/tmexp/utils.py
+++ b/tmexp/utils.py
@@ -26,6 +26,12 @@ SUPPORTED_LANGUAGES = [
     "TypeScript",
 ]
 
+FEATURE_DIR = "FEATURE_DIR"
+FEATURE_DEFAULT_FILENAME = "features.pkl"
+BOW_DIR = "BOW_DIR"
+TOPICS_DIR = "TOPICS_DIR"
+VIZ_DIR = "VIZ_DIR"
+
 
 class TqdmLoggingHandler(Handler):
     def __init__(self, level: int = NOTSET) -> None:
@@ -49,9 +55,18 @@ def create_logger(log_level: str, name: str) -> Logger:
     return logger
 
 
-def check_exists(file_path: str) -> None:
+def check_file_exists(file_path: str) -> None:
     if not os.path.exists(file_path):
         raise RuntimeError("File '%s' does not exists, aborting." % file_path)
+
+
+def check_env_exists(env_name: str, arg_name: str) -> str:
+    if env_name not in os.environ:
+        raise RuntimeError(
+            "Variable '%s' does not exists, aborting (either create it or"
+            "specify argument '%s')." % (env_name, arg_name)
+        )
+    return os.environ[env_name]
 
 
 def check_remove_file(file_path: str, logger: Logger, force: bool) -> None:

--- a/tmexp/utils.py
+++ b/tmexp/utils.py
@@ -40,6 +40,8 @@ WORDTOPIC_FILENAME = "word.topic.npy"
 
 VIZ_DIR = "/data/visualisations"
 
+CUR_TIME = None
+
 
 class TqdmLoggingHandler(Handler):
     def __init__(self, level: int = NOTSET) -> None:
@@ -63,11 +65,11 @@ def create_logger(log_level: str, name: str) -> Logger:
     return logger
 
 
-def check_create_default(name: Optional[str], out_type: str, logger: Logger) -> str:
-    if name is None:
-        name = "%s-%s" % (time.strftime("%m-%d-%H:%M"), out_type)
-        logger.info("Created default %s name: '%s'", out_type, name)
-    return name
+def check_create_default(out_type: str) -> str:
+    global CUR_TIME
+    if CUR_TIME is None:
+        CUR_TIME = time.strftime("%m-%d-%H:%M")
+    return "%s-%s" % (CUR_TIME, out_type)
 
 
 def check_file_exists(file_path: str) -> None:


### PR DESCRIPTION
So, in this PR there are 3 commits.

**Commit 1:**

Add Dockerfile and requirements file. I always like to install requirements separately from the library when building Docker images, hence the requirements. As you can see there is a certain amount of ENV variables, going to get to that. 

**Commit 2:**

Here I add the env variable logic. This is directly inspired from modelforge, the idea is that is way easier to centralize everything in one directory, which allows us to remove a lot of the logic by simply specifying environment variables. 

If you agree, I would like to go further, assume that Docker will be used in all cases, and remove all mentions of input/output paths in the command, keeping only:

- For the output of `preprocess`, replace `output-dir` with `dataset-name`
- For the input of `create_bow` thus we can just specify `dataset-name`, and `bow-name` for the output
- For the input of `train_hdp` or other model training just specify `bow-name` and optionally `experiment-name` 
- For the input of postprocessing commands specify  `bow-name` and optionnaly `experiemnt-name`, and that's it.

I think it would be better this way, and the data will be stored in a logical way:
```
/data
/data/features
/data/features/dataset_1.pkl
/data/features/dataset_2.pkl
/data/bow
/data/bow/bow_1/
/data/bow/bow_1/docs.bow_tm.txt
/data/bow/bow_1/docword.bow_tm.txt
/data/bow/bow_1/vocab.bow_tm.txt
/data/topics
/data/topics/bow_1/
/data/topics/bow_1/experiment_1/
...
```

**Commit 3:**

Updated the README.md