### PR TITLE
Add artm model

### DIFF
--- a/tmexp/__main__.py
+++ b/tmexp/__main__.py
@@ -9,6 +9,7 @@ from .merge import merge_datasets
 from .metrics import compute_metrics
 from .postprocess import postprocess
 from .preprocess import COMMENTS, IDENTIFIERS, LITERALS, preprocess
+from .train_artm import train_artm
 from .train_hdp import train_hdp
 from .utils import check_create_default, SUPPORTED_LANGUAGES
 from .visualize import visualize
@@ -258,6 +259,90 @@ def get_parser() -> argparse.ArgumentParser:
         help="Lower bound on the right side of convergence.",
         default=0.0001,
         type=float,
+    )
+    # ------------------------------------------------------------------------
+
+    train_artm_parser = subparsers.add_parser(
+        "train_artm", help="Train ARTM model from the input BoW."
+    )
+    train_artm_parser.set_defaults(handler=train_artm)
+
+    add_bow_arg(train_artm_parser, required=True)
+    add_experiment_arg(train_artm_parser, required=False)
+    add_force_arg(train_artm_parser)
+    train_artm_parser.add_argument(
+        "--batch-size",
+        help="Number of documents to be stored in each batch, defaults to %(default)s.",
+        default=1000,
+        type=int,
+    )
+    train_artm_parser.add_argument(
+        "--max-topic",
+        help="Maximum number of topics, used as initial value.",
+        default=200,
+        type=int,
+    )
+    train_artm_parser.add_argument(
+        "--converge-thresh",
+        help="When the selection metric does not improve more then this between passes "
+        "we assume convergence, defaults to %(default)s.",
+        default=0.001,
+        type=float,
+    )
+    train_artm_parser.add_argument(
+        "--converge-metric",
+        help="Selection metric to use.",
+        choices=["perplexity", "distinctness"],
+        default="distinctness",
+    )
+    train_artm_parser.add_argument(
+        "--sparse-word-coeff",
+        help="Coefficient used by the sparsity inducing regularizer for the word topic "
+        "distribution (phi) defaults to %(default)s.",
+        default=0.5,
+        type=float,
+    )
+    train_artm_parser.add_argument(
+        "--sparse-doc-coeff",
+        help="Coefficient used by the sparsity inducing regularizer for the doc topic "
+        "distribution (theta), defaults to %(default)s.",
+        default=0.5,
+        type=float,
+    )
+    train_artm_parser.add_argument(
+        "--decor-coeff",
+        help="Coefficient used by the topic decorrelation regularizer, defaults to "
+        "%(default)s.",
+        default=1e5,
+        type=float,
+    )
+    train_artm_parser.add_argument(
+        "--select-coeff",
+        help="Coefficient used by the topic selection regularizer, defaults to "
+        "%(default)s.",
+        default=0.1,
+        type=float,
+    )
+    train_artm_parser.add_argument(
+        "--doctopic-eps",
+        help="Minimum document topic probability, used as tolerance when computing "
+        "sparsity of the document topic matrix, defaults to %(default)s.",
+        default=0.1,
+        type=float,
+    )
+    train_artm_parser.add_argument(
+        "--wordtopic-eps",
+        help="Minimum word topic probability, used as tolerance when computing "
+        "sparsity of the word topic matrix, defaults to %(default)s.",
+        default=1e-4,
+        type=float,
+    )
+    train_artm_parser.add_argument(
+        "-q",
+        "--quiet",
+        help="To only output scores of first and last iteration during each training "
+        "phases",
+        action="store_true",
     )
     # ------------------------------------------------------------------------
 

--- a/tmexp/create_bow.py
+++ b/tmexp/create_bow.py
@@ -164,7 +164,7 @@ def create_bow(
     sorted_vocabulary = sorted(
         word for word in doc_freq if word not in blacklisted_words
     )
-    word_index = {word: i for i, word in enumerate(sorted_vocabulary)}
+    word_index = {word: i for i, word in enumerate(sorted_vocabulary, start=1)}
     num_words = len(word_index)
     logger.info("Number of distinct words: %d" % num_words)
     logger.info("Saving word index ...")

--- a/tmexp/label.py
+++ b/tmexp/label.py
@@ -70,7 +70,7 @@ def label_topics(
         corpus = np.zeros((num_docs, num_words))
         for line in fin:
             doc_id, word_id, count = map(int, line.split())
-            corpus[doc_id, word_id] = count
+            corpus[doc_id, word_id - 1] = count
     logger.info("Loaded %d bags of words from %d %s.", num_bags, num_docs, doc_type)
     if topic_model == DIFF_MODEL:
         logger.info("Loading tagged refs ...")

--- a/tmexp/train_artm.py
+++ b/tmexp/train_artm.py
@@ -1,0 +1,176 @@
+import logging
+import os
+from typing import Dict
+import warnings
+
+from artm import (
+    ARTM,
+    BatchVectorizer,
+    DecorrelatorPhiRegularizer,
+    PerplexityScore,
+    SmoothSparsePhiRegularizer,
+    SmoothSparseThetaRegularizer,
+    SparsityPhiScore,
+    SparsityThetaScore,
+    TopicSelectionThetaRegularizer,
+)
+import numpy as np
+
+from .io_constants import (
+    BOW_DIR,
+    DOCTOPIC_FILENAME,
+    DOCWORD_FILENAME,
+    TOPICS_DIR,
+    VOCAB_FILENAME,
+    WORDTOPIC_FILENAME,
+)
+from .metrics import compute_distinctness
+from .utils import check_file_exists, check_remove, create_directory, create_logger
+
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+
+
+def print_scores(
+    logger: logging.Logger, num_iter: int, scores: Dict[str, float]
+) -> None:
+    logger.info("\tIteration %d", num_iter)
+    for label, score in scores.items():
+        logger.info("\t\t%s : %.4f", label, score)
+
+
+def compute_scores(model: ARTM) -> Dict[str, float]:
+    scores: Dict[str, float] = {}
+    for label in ["Topic Sparsity", "Doc Sparsity", "Perplexity"]:
+        scores[label.lower()] = model.score_tracker[label].last_value
+    wordtopic, words, topics = model.get_phi_dense()
+    scores["distinctness"] = np.mean(
+        np.sum(compute_distinctness(wordtopic.T, len(topics), len(words)), axis=1)
+        / (len(topics) - 1)
+    )
+    return scores
+
+
+def loop_until_convergence(
+    logger: logging.Logger,
+    batch_vectorizer: BatchVectorizer,
+    model_artm: ARTM,
+    converge_metric: str,
+    converge_thresh: float,
+    quiet: bool,
+) -> ARTM:
+    converged = False
+    num_iter = 0
+    prev_score = np.inf
+    while not converged:
+        num_iter += 1
+        model_artm.fit_offline(
+            batch_vectorizer=batch_vectorizer, num_collection_passes=1, reset_nwt=False
+        )
+        scores = compute_scores(model_artm)
+        score = scores[converge_metric]
+        converged = abs(score - prev_score) / prev_score < converge_thresh
+        if converged or not quiet or num_iter == 1:
+            print_scores(logger, num_iter, scores)
+        prev_score = score
+    return model_artm
+
+
+def train_artm(
+    bow_name: str,
+    exp_name: str,
+    force: bool,
+    batch_size: int,
+    max_topic: int,
+    converge_metric: str,
+    converge_thresh: float,
+    sparse_word_coeff: float,
+    sparse_doc_coeff: float,
+    decor_coeff: float,
+    select_coeff: float,
+    doctopic_eps: float,
+    wordtopic_eps: float,
+    quiet: bool,
+    log_level: str,
+) -> None:
+    logger = create_logger(log_level, __name__)
+
+    input_dir = os.path.join(BOW_DIR, bow_name)
+    check_file_exists(os.path.join(input_dir, VOCAB_FILENAME))
+    check_file_exists(os.path.join(input_dir, DOCWORD_FILENAME))
+
+    output_dir = os.path.join(TOPICS_DIR, bow_name, exp_name)
+    doctopic_output_path = os.path.join(output_dir, DOCTOPIC_FILENAME)
+    check_remove(doctopic_output_path, logger, force)
+    wordtopic_output_path = os.path.join(output_dir, WORDTOPIC_FILENAME)
+    check_remove(wordtopic_output_path, logger, force)
+    create_directory(output_dir, logger)
+
+    logger.info("Loading bags of words ...")
+    batch_vectorizer = BatchVectorizer(
+        collection_name="bow_tm",
+        data_path=input_dir,
+        data_format="bow_uci",
+        batch_size=batch_size,
+    )
+    logger.info(
+        "Loaded bags of words, created %d batches of up to %d documents.",
+        batch_vectorizer.num_batches,
+        batch_size,
+    )
+    model_artm = ARTM(
+        cache_theta=True,
+        dictionary=batch_vectorizer.dictionary,
+        num_document_passes=1,
+        num_topics=max_topic,
+        scores=[
+            PerplexityScore(name="Perplexity", dictionary=batch_vectorizer.dictionary),
+            SparsityPhiScore(name="Topic Sparsity", eps=wordtopic_eps),
+            SparsityThetaScore(name="Doc Sparsity", eps=doctopic_eps),
+        ],
+        regularizers=[
+            SmoothSparsePhiRegularizer(name="Sparse Topic", tau=0),
+            SmoothSparseThetaRegularizer(name="Sparse Doc", tau=0),
+            DecorrelatorPhiRegularizer(name="Decorrelator", tau=decor_coeff),
+            TopicSelectionThetaRegularizer(name="Selector", tau=0),
+        ],
+    )
+    logger.info("Starting training ...")
+
+    logger.info("Decorrelating topics ...")
+    model_artm = loop_until_convergence(
+        logger, batch_vectorizer, model_artm, converge_metric, converge_thresh, quiet
+    )
+    model_artm.regularizers["Sparse Topic"].tau = 0
+    model_artm.regularizers["Sparse Doc"].tau = 0
+    model_artm.regularizers["Decorrelator"].tau = 0
+    model_artm.regularizers["Selector"].tau = select_coeff
+    logger.info("Selecting topics ...")
+    model_artm = loop_until_convergence(
+        logger, batch_vectorizer, model_artm, converge_metric, converge_thresh, quiet
+    )
+    model_artm.regularizers["Selector"].tau = 0
+    model_artm.regularizers["Decorrelator"].tau = decor_coeff
+    model_artm.regularizers["Sparse Topic"].tau = -sparse_word_coeff
+    model_artm.regularizers["Sparse Doc"].tau = -sparse_doc_coeff
+    doctopic, _, _ = model_artm.get_theta_sparse(eps=doctopic_eps)
+    doctopic = doctopic.todense()
+    topics = np.argwhere((doctopic).any(1)).flatten()
+    topic_names = [t for i, t in enumerate(model_artm.topic_names) if i in topics]
+    model_artm.reshape(topic_names)
+    logger.info("New number of topics: %d", len(topic_names))
+    logger.info("Inducing sparsity ...")
+    model_artm = loop_until_convergence(
+        logger, batch_vectorizer, model_artm, converge_metric, converge_thresh, quiet
+    )
+
+    logger.info("Finished training.")
+    doctopic, _, _ = model_artm.get_theta_sparse()
+    doctopic = doctopic.todense()
+    logger.info("Saving topics per document ...")
+    np.save(doctopic_output_path, doctopic.T)
+    logger.info("Saved topics per document in '%s'.", doctopic_output_path)
+
+    wordtopic, _, _ = model_artm.get_phi_dense()
+    logger.info("Saving word/topic distribution ...")
+    np.save(wordtopic_output_path, wordtopic.T)
+    logger.info("Saved word/topic distribution in '%s'.", wordtopic_output_path)

--- a/tmexp/train_hdp.py
+++ b/tmexp/train_hdp.py
@@ -63,7 +63,7 @@ def train_hdp(
     logger.info("Loading vocabulary ...")
     with open(words_input_path, "r", encoding="utf-8") as fin:
         word_index: Dict[int, str] = {
-            i: word.replace("\n", "") for i, word in enumerate(fin)
+            i: word.replace("\n", "") for i, word in enumerate(fin, start=1)
         }
     id2word = gensim.corpora.Dictionary.from_corpus(corpus, word_index)
     logger.info("Word index created.")

--- a/tmexp/visualize.py
+++ b/tmexp/visualize.py
@@ -79,7 +79,7 @@ def visualize(
     logger.info("Loading metrics ...")
     with open(metrics_input_path, "rb") as fin_b:
         metrics = pickle.load(fin_b)
-    num_topics = metrics["similarity"].shape[0]
+    num_topics = metrics["distinctness"].shape[0]
     logger.info("Loaded metrics, found %d topics." % num_topics)
 
     logger.info("Loading topic labels ...")
@@ -95,7 +95,7 @@ def visualize(
     for ind_topic in tqdm.tqdm(range(num_topics)):
         plt.figure(figsize=(10, 5))
         for metric_name, metric in metrics.items():
-            if metric_name == "similarity":
+            if metric_name == "distinctness":
                 continue
             plt.plot(ref_ticks, metric[:, ind_topic], "-+", label=metric_name)
         plt.xlabel("Tagged reference", fontsize=14)
@@ -113,9 +113,9 @@ def visualize(
     logger.info("Creating and saving heatmaps  per metric ...")
     for metric_name, metric in metrics.items():
         output_path = os.path.join(output_dir, HEATMAP_FILENAME % metric_name)
-        if metric_name == "similarity":
+        if metric_name == "distinctness":
             label = "Topic index"
-            title = "Topic similarity"
+            title = "Topic distinctness"
             create_heatmap(output_path, metric, title, 0, np.max(metric), label, label)
         else:
             metric = metric.T


### PR DESCRIPTION
3 commits in this PR

**commit 1**

ARTM uses unary based word index, not zero based - for some reason here they care, but for docs nop --". It doesn't really change anything for us, so now we do as well.

**commit 2**

Renamed similarity to distinctness as it's confusing to see the similarity metric increase when topics get more distinct. Also put the computation of the `n_topic x n_topics` matrix in a separate function for reuse.

**commit 3**

Added the artm train. Changes in main are pretty self evident, for the core logic I decided to use the training procedure described in [Voronstov's paper](https://userpages.umbc.edu/~kogan/teaching/m710/15fall/papers/Voron15slds.pdf) as it seemed equivalent, and rather logical - also did not want to increase complexity with number of iterations at which to start each regularizer, alternating between decorrrelation and selection, etc. I checked manually, there is no need to repeat steps 2 and 3 as they do not increase quality after convergence (quite the opposite from my tests).

Regarding default params, I have not tried to fine tune the reg parameters too much, however:
- the converge threshold at 0.1 % seems to work nicely
- so does considering an entry in the doctopic matrix is null if prob is under 0.1 (I tried 0.01, the number of topics did not budge, which is not so suprising)

I've trained with the default params on the old data extracted from pytorch (711 words, 16766 delta documents), I got these results:

- Using similarity metric: 65 topics
		word sparsity : 0.3868
		doc sparsity : 0.9821
		perplexity : 186.9207
		distinctness : 0.8213

- Using perplexity metric: 56 topics
		word sparsity : 0.4033
		doc sparsity : 0.9776
		perplexity : 176.3352
		distinctness : 0.7454

