### PR TITLE
Adapt tmexp for multi-repo HEAD-only vendors-excluded processing

### DIFF
--- a/tmexp/__main__.py
+++ b/tmexp/__main__.py
@@ -133,6 +133,12 @@ def get_parser() -> argparse.ArgumentParser:
         default=[],
     )
     preprocess_parser.add_argument(
+        "--keep-vendors", help="Keep vendors in processed files.", action="store_true"
+    )
+    preprocess_parser.add_argument(
+        "--only-head", help="Preprocess only the head revision.", action="store_true"
+    )
+    preprocess_parser.add_argument(
         "--only-by-date",
         help="To sort the references only by date (may cause errors).",
         action="store_true",
@@ -371,6 +377,13 @@ def get_parser() -> argparse.ArgumentParser:
         help="Compute document word count and membership given a topic model.",
     )
     postprocess_parser.set_defaults(handler=postprocess)
+    # TODO(https://github.com/src-d/tm-experiments/issues/21)
+    postprocess_parser.add_argument(
+        "--original-document-index",
+        action="store_true",
+        help="Use the original document index instead of the workaround computed "
+        "during ARTM training.",
+    )
     add_bow_arg(postprocess_parser, required=True)
     add_experiment_arg(postprocess_parser, required=True)
     add_force_arg(postprocess_parser)

--- a/tmexp/gitbase_queries.py
+++ b/tmexp/gitbase_queries.py
@@ -1,37 +1,63 @@
-TAGGED_REFS = """
-SELECT rf.ref_name
-FROM repositories r
-    NATURAL JOIN refs rf
-    NATURAL JOIN commits c
-WHERE r.repository_id = '%s' AND is_tag(rf.ref_name)
-ORDER BY c.committer_when;
-"""
+from typing import List
 
-FILE_INFO = """
-SELECT rf.ref_name,
-    cf.file_path,
-    cf.blob_hash,
-    LANGUAGE(cf.file_path) as lang
-FROM repositories r
-    NATURAL JOIN refs rf
-    NATURAL JOIN commit_files cf
-WHERE r.repository_id = '%s'
-    AND rf.ref_name in (%s)
-    AND lang in (%s);
-"""
 
-FILE_CONTENT = """
-SELECT DISTINCT
-    cf.file_path,
-    cf.blob_hash,
-    LANGUAGE(cf.file_path) as lang,
-    f.blob_content
-FROM repositories r
-    NATURAL JOIN refs rf
-    NATURAL JOIN commit_files cf
-    NATURAL JOIN files f
-WHERE r.repository_id = '%s'
-    AND is_tag(rf.ref_name)
-    AND rf.ref_name in (%s)
-    AND lang in (%s);
-"""
+def get_tagged_refs_sql(*, repository_id: str) -> str:
+    return (
+        """
+        SELECT rf.ref_name
+        FROM repositories r
+            NATURAL JOIN refs rf
+            NATURAL JOIN commits c
+        WHERE r.repository_id = '%s' AND is_tag(rf.ref_name)
+        ORDER BY c.committer_when;
+        """
+        % repository_id
+    )
+
+
+def get_file_info_sql(
+    *, repository_id: str, ref_names: List[str], langs: List[str], exclude_vendors: bool
+) -> str:
+    return """
+        SELECT rf.ref_name,
+            cf.file_path,
+            cf.blob_hash,
+            LANGUAGE(cf.file_path) AS lang
+        FROM repositories r
+            NATURAL JOIN refs rf
+            NATURAL JOIN commit_files cf
+        WHERE r.repository_id = '%s'
+            AND rf.ref_name IN (%s)
+            AND lang IN (%s)
+            %s;
+        """ % (
+        repository_id,
+        ",".join("'%s'" % ref_name for ref_name in ref_names),
+        ",".join("'%s'" % lang for lang in langs),
+        "AND NOT IS_VENDOR(cf.file_path)" if exclude_vendors else "",
+    )
+
+
+def get_file_content_sql(
+    *, repository_id: str, ref_names: List[str], langs: List[str], exclude_vendors: bool
+) -> str:
+    return """
+        SELECT DISTINCT
+            cf.file_path,
+            cf.blob_hash,
+            LANGUAGE(cf.file_path) AS lang,
+            f.blob_content
+        FROM repositories r
+            NATURAL JOIN refs rf
+            NATURAL JOIN commit_files cf
+            NATURAL JOIN files f
+        WHERE r.repository_id = '%s'
+            AND rf.ref_name IN (%s)
+            AND lang IN (%s)
+            %s;
+        """ % (
+        repository_id,
+        ",".join("'%s'" % ref_name for ref_name in ref_names),
+        ",".join("'%s'" % lang for lang in langs),
+        "AND NOT IS_VENDOR(cf.file_path)" if exclude_vendors else "",
+    )

--- a/tmexp/io_constants.py
+++ b/tmexp/io_constants.py
@@ -8,6 +8,8 @@ VOCAB_FILENAME = "vocab.bow_tm.txt"
 
 TOPICS_DIR = "/data/topics"
 DOCTOPIC_FILENAME = "doctopic.npy"
+# TODO(https://github.com/src-d/tm-experiments/issues/21)
+DOC_ARTM_FILENAME = "doc.artm.txt"
 WORDTOPIC_FILENAME = "wordtopic.npy"
 MEMBERSHIP_FILENAME = "membership.pkl"
 WORDCOUNT_FILENAME = "wordcount.pkl"

--- a/tmexp/postprocess.py
+++ b/tmexp/postprocess.py
@@ -1,13 +1,14 @@
 from collections import Counter, defaultdict
 import os
 import pickle
-from typing import Dict
+from typing import Counter as CounterType, DefaultDict, Dict, List
 
 import numpy as np
 
 from .create_bow import DIFF_MODEL, HALL_MODEL, SEP
 from .io_constants import (
     BOW_DIR,
+    DOC_ARTM_FILENAME,
     DOC_FILENAME,
     DOCTOPIC_FILENAME,
     DOCWORD_FILENAME,
@@ -19,19 +20,30 @@ from .io_constants import (
 from .utils import check_file_exists, check_remove, create_logger
 
 
-def postprocess(bow_name: str, exp_name: str, force: bool, log_level: str) -> None:
+def postprocess(
+    bow_name: str,
+    exp_name: str,
+    force: bool,
+    # TODO(https://github.com/src-d/tm-experiments/issues/21)
+    original_document_index: bool,
+    log_level: str,
+) -> None:
 
     logger = create_logger(log_level, __name__)
 
     input_dir_bow = os.path.join(BOW_DIR, bow_name)
-    doc_input_path = os.path.join(input_dir_bow, DOC_FILENAME)
+    dir_exp = os.path.join(TOPICS_DIR, bow_name, exp_name)
+    # TODO(https://github.com/src-d/tm-experiments/issues/21)
+    if original_document_index:
+        doc_input_path = os.path.join(input_dir_bow, DOC_FILENAME)
+    else:
+        doc_input_path = os.path.join(dir_exp, DOC_ARTM_FILENAME)
     check_file_exists(doc_input_path)
     docword_input_path = os.path.join(input_dir_bow, DOCWORD_FILENAME)
     check_file_exists(docword_input_path)
     refs_input_path = os.path.join(input_dir_bow, REF_FILENAME)
     check_file_exists(refs_input_path)
 
-    dir_exp = os.path.join(TOPICS_DIR, bow_name, exp_name)
     doctopic_input_path = os.path.join(dir_exp, DOCTOPIC_FILENAME)
     check_file_exists(doctopic_input_path)
 
@@ -42,8 +54,14 @@ def postprocess(bow_name: str, exp_name: str, force: bool, log_level: str) -> No
 
     logger.info("Loading tagged refs ...")
     with open(refs_input_path, "r", encoding="utf-8") as fin:
-        refs = fin.read().split("\n")
-    logger.info("Loaded tagged refs, found %d." % len(refs))
+        refs: DefaultDict[str, List[str]] = defaultdict(list)
+        for line in fin:
+            repo, ref = line.split(SEP)
+            refs[repo].append(ref)
+    logger.info(
+        "Loaded tagged refs, found %d."
+        % sum(len(repo_refs) for repo_refs in refs.values())
+    )
 
     logger.info("Loading document topics matrix ...")
     doctopic = np.load(doctopic_input_path)
@@ -53,7 +71,7 @@ def postprocess(bow_name: str, exp_name: str, force: bool, log_level: str) -> No
     )
 
     logger.info("Loading document word counts ...")
-    docword: Dict[int, int] = Counter()
+    docword: CounterType[int] = Counter()
     with open(docword_input_path, "r", encoding="utf-8") as fin:
         for _ in range(3):
             fin.readline()
@@ -62,17 +80,21 @@ def postprocess(bow_name: str, exp_name: str, force: bool, log_level: str) -> No
             docword[ind_doc] += count
     logger.info("Loaded word counts.")
 
-    membership: Dict[str, Dict[str, np.array]] = defaultdict(dict)
-    wordcount: Dict[str, Dict[str, int]] = defaultdict(dict)
+    membership: DefaultDict[str, DefaultDict[str, Dict[str, np.array]]] = defaultdict(
+        lambda: defaultdict(dict)
+    )
+    wordcount: DefaultDict[str, DefaultDict[str, Dict[str, int]]] = defaultdict(
+        lambda: defaultdict(dict)
+    )
 
     logger.info("Loading document index ...")
     with open(doc_input_path, "r", encoding="utf-8") as fin:
         line = fin.readline()
         if ":added" in line or ":removed" in line:
             topic_model = DIFF_MODEL
-            diff_mapping: Dict[str, Dict[str, Dict[str, int]]] = defaultdict(
-                lambda: defaultdict(dict)
-            )
+            diff_mapping: DefaultDict[
+                str, DefaultDict[str, DefaultDict[str, Dict[str, int]]]
+            ] = defaultdict(lambda: defaultdict(lambda: defaultdict(dict)))
         else:
             topic_model = HALL_MODEL
         fin.seek(0)
@@ -82,43 +104,49 @@ def postprocess(bow_name: str, exp_name: str, force: bool, log_level: str) -> No
     logger.info("Computing topic membership and total word count per document ...")
     for ind_doc in range(num_docs):
         name_refs = doc_index[ind_doc].split()
-        doc_name = name_refs[0].split(SEP)[0]
+        doc_name = name_refs[0].split(SEP)
+        doc_repo = doc_name[0]
+        doc_path = doc_name[1]
         doc_refs = name_refs[1:]
         if topic_model == DIFF_MODEL:
-            doc_type = name_refs[0].split(SEP)[1]
-            diff_mapping[doc_refs[0]][doc_name][doc_type] = ind_doc
+            doc_type = doc_name[2]
+            diff_mapping[doc_repo][doc_refs[0]][doc_path][doc_type] = ind_doc
             for ref in doc_refs[1:]:
-                diff_mapping[ref][doc_name][doc_type] = None
+                diff_mapping[ref][doc_path][doc_type] = None
         else:
             for ref in doc_refs:
-                membership[ref][doc_name] = doctopic[ind_doc, :]
-                wordcount[ref][doc_name] = docword[ind_doc]
+                membership[doc_repo][ref][doc_path] = doctopic[ind_doc, :]
+                wordcount[doc_repo][ref][doc_path] = docword[ind_doc]
     if topic_model == DIFF_MODEL:
-        last_membership: Dict[str, np.array] = defaultdict(lambda: np.zeros(num_topics))
-        last_wordcount: Dict[str, int] = defaultdict(int)
-        for ref in refs:
-            for doc_name, doc_mapping in diff_mapping[ref].items():
-                last = last_membership[doc_name]
-                last_wc = last_wordcount[doc_name]
-                add_wc, rem_wc = 0, 0
-                add, rem = np.zeros(num_topics), np.zeros(num_topics)
-                if "added" in doc_mapping and doc_mapping["added"] is not None:
-                    add_wc += docword[doc_mapping["added"]]
-                    add += doctopic[doc_mapping["added"], :]
-                if "removed" in doc_mapping and doc_mapping["removed"] is not None:
-                    rem_wc += docword[doc_mapping["removed"]]
-                    rem += doctopic[doc_mapping["removed"], :]
 
-                cur = np.zeros(num_topics)
-                cur_wc = last_wc + add_wc - rem_wc
-                if cur_wc:
-                    wordcount[ref][doc_name] = cur_wc
-                    cur = (last * last_wc + add * add_wc - rem * rem_wc) / cur_wc
-                    cur[cur > 1] = 1
-                    cur[cur <= 0] = 1e-20
-                    membership[ref][doc_name] = cur
-                last_wordcount[doc_name] = cur_wc
-                last_membership[doc_name] = cur
+        for repo, repo_refs in refs.items():
+            last_membership: DefaultDict[str, np.array] = defaultdict(
+                lambda: np.zeros(num_topics)
+            )
+            last_wordcount: CounterType[str] = Counter()
+            for ref in repo_refs:
+                for doc_path, doc_mapping in diff_mapping[repo][ref].items():
+                    last = last_membership[doc_path]
+                    last_wc = last_wordcount[doc_path]
+                    add_wc, rem_wc = 0, 0
+                    add, rem = np.zeros(num_topics), np.zeros(num_topics)
+                    if "added" in doc_mapping and doc_mapping["added"] is not None:
+                        add_wc += docword[doc_mapping["added"]]
+                        add += doctopic[doc_mapping["added"], :]
+                    if "removed" in doc_mapping and doc_mapping["removed"] is not None:
+                        rem_wc += docword[doc_mapping["removed"]]
+                        rem += doctopic[doc_mapping["removed"], :]
+
+                    cur = np.zeros(num_topics)
+                    cur_wc = last_wc + add_wc - rem_wc
+                    if cur_wc:
+                        wordcount[repo][ref][doc_path] = cur_wc
+                        cur = (last * last_wc + add * add_wc - rem * rem_wc) / cur_wc
+                        cur[cur > 1] = 1
+                        cur[cur <= 0] = 1e-20
+                        membership[repo][ref][doc_path] = cur
+                    last_wordcount[doc_path] = cur_wc
+                    last_membership[doc_path] = cur
     logger.info("Computed topic membership per reference.")
 
     logger.info("Saving document memberships ...")

--- a/tmexp/utils.py
+++ b/tmexp/utils.py
@@ -1,9 +1,15 @@
+from collections.abc import Mapping, MutableMapping
 import logging
 from logging import Handler, Logger, LogRecord, NOTSET
 import os
 import shutil
 import time
-from typing import List, Optional
+from typing import (
+    List,
+    Mapping as MappingType,
+    MutableMapping as MutableMappingType,
+    Optional,
+)
 
 import tqdm
 
@@ -116,3 +122,18 @@ def create_language_list(
         if exclude_langs is not None:
             langs = [lang for lang in langs if lang not in exclude_langs]
     return langs
+
+
+def recursive_update(d: MutableMappingType, u: MappingType) -> None:
+    def recursive_worker(d: MutableMappingType, u: MappingType) -> MutableMappingType:
+        for k, v in u.items():
+            dv = d.get(k, {})
+            if not isinstance(dv, MutableMapping):
+                d[k] = v
+            elif isinstance(v, Mapping):
+                d[k] = recursive_worker(dv, v)
+            else:
+                d[k] = v
+        return d
+
+    recursive_worker(d, u)


### PR DESCRIPTION
Contains the tweaks I implemented to enable multi-repo processing on HEAD revisions with vendors excluded for the incoming demo. Better reviewed commit by commit :sweat_smile: