### PR TITLE
Add nn option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM ubuntu:18.04
 
 RUN mkdir /data /package /nltk_data
 
-ARG DEBIAN_FRONTEND=noninteractive 
+ARG DEBIAN_FRONTEND=noninteractive
+ARG USE_NN=false
 
 ENV BBLFSH_HOSTNAME tmexp_bblfshd
 ENV BBLFSH_PORT 9432
@@ -67,8 +68,9 @@ RUN pip3 install --no-cache-dir -r /package/requirements.txt
 
 COPY setup.py /package
 COPY README.md /package
+COPY install.sh /package
 COPY tmexp /package/tmexp
 
-RUN pip3 install --no-cache-dir /package/.
+RUN chmod u+x /package/install.sh && /package/install.sh $USE_NN
 
 ENTRYPOINT ["tmexp"]

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ git clone https://github.com/src-d/tm-experiments
 docker build tm-experiments -t tmexp
 ```
 
+If you have GPU(s) and want to use our lit [Neural Identifier Splitter](https://arxiv.org/abs/1805.11651) then consider building the image with:
+
+```
+docker build tm-experiments -t tmexp --build-arg USE_NN=true
+```
+
 In all of the following, all of the created data will be stored in a single directory (hereinafter referred to as `/path/to/data`), which would have the following structure if you were to run with the exact same names:
 
 ```

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ "$1" = true ]; then  
+    pip3 install --no-cache-dir /package/.[nn]
+else
+    pip3 install --no-cache-dir /package/.
+fi

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         "gensim==3.7.3",
         "matplotlib==3.1.1",
     ],
+    extras_require={"nn": ["sourced-ml-core[tf_gpu]>=0.0.4"]},
     include_package_data=True,
     license="Apache-2.0",
     classifiers=[


### PR DESCRIPTION
Fixes #27.

- I added the nn-splitter as an extras in the `setup.py`, and an optional flag in prepoc activates it. if activated, it is used after `camelCase` and `snake_case` splitting previously done (could be used instead ?)
- I updated the Dockerfile in consequence (created a small bash script so it stays pretty), the image can be built with the `USE_NN` flag set to true (any other value of lack of value will be interpreted as False)
- Added explanations to the README (which I think I will update to day as it is outdated)

Note: I have tested both build options (long w/ my connections but both work) and have checked that both work w/o the flag. I did not add any error handling in the preprocess as the errors are pretty explicit:

- `ModuleNotFound` if using the no-nn image with the flag
- `ImportError` if using the nn-image with the flag, but without GPU ;P

I was not able to check the code worked, as I do not have a GPU on my laptop.