### PR TITLE
Port refactoring to label

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,16 +35,16 @@ data
     └── my-bow
         ├── my-artm-exp
         │   ├── doctopic.npy
-        │   └── wordtopic.npy
+        │   ├── wordtopic.npy
+        │   └── labels.txt
         └── my-hdp-exp
             ├── doctopic.npy
             └── wordtopic.npy
-
 ```
 
 For all commands we only specify the required arguments, check the optional ones with `docker run --rm -i tmexp $CMD --help`
 
-### Preprocess
+### `preprocess` command
 
 This command will allow you to create a dataset from a cloned git repository. Before launching the command, you will thus need to clone one (or multiple) repository in a directory, as well as start the Babelfish and Gitbase servers:
 
@@ -62,13 +62,13 @@ docker run --rm -it -v /path/to/data:/data \
   tmexp preprocess -r repo --dataset-name my-dataset
 ```
 
-Once your job is finished, the output file should be located in `/path/to/data/datasets/`. Unless you wish to run this command once more, you can remove the Babelfish and Gitbase containers, as they will not be of further use, with:
+Once this job is finished, the output file should be located in `/path/to/data/datasets/`. Unless you wish to run this command once more, you can remove the Babelfish and Gitbase containers, as they will not be of further use, with:
 
 `docker stop tmexp_gitbase tmexp_bblfshd`
 
 For the sake of explaining the next command, we assume you ran it a second time, and created a dataset named `my-dataset-2`.
 
-### Merge
+### `merge` command
 
 This command will allow you to merge multiple dataset created by the previous command. Assuming you created the two datasets, `my-dataset` and `my-dataset-2`, you can launch the merging with the following command:
 
@@ -77,9 +77,9 @@ docker run --rm -it -v /path/to/data:/data \
   tmexp merge -i my-dataset my-dataset-2 -r repo --dataset-name my-merged-dataset
 ```
 
-Once your job is finished, the output file should be located in `/path/to/data/datasets/`.
+Once this job is finished, the output file should be located in `/path/to/data/datasets/`.
 
-### Create BoW
+### `create-bow` command
 
 This command will allow you to create the input used for the topic modeling, ie bags of words, from datasets created by one of the above commads. You will need to choose between one of two topic evolution models, `hall` or `diff` (for more information, ou can check out [this paper](https://arxiv.org/abs/1704.00135)). You can launch the bag of words creation with the following command (don't forget to specify the dataset name and the topic evolution model you want to use):
 
@@ -88,9 +88,9 @@ docker run --rm -it -v /path/to/data:/data \
   tmexp create-bow --topic-model diff --dataset-name my-dataset --bow-name my-bow
 ```
 
-Once your job is finished, the output files should be located in `/path/to/data/bows/my-bow/`
+Once this job is finished, the output files should be located in `/path/to/data/bows/my-bow/`
 
-### Train ARTM
+### `train-artm` command
 
 This command will allow you to create an ARTM model from the bags-of-words created previously. You will need to specify the minimum amount of documents belonging to a given topic (by default, belonging means the document has a topic probability over .5) for this topic to be kept, which can either be an absolute number of documents, or relative to the number of documents. You can launch the training with the following command (don't forget to specify the bow name and one of the `min-docs` arguments):
 
@@ -99,9 +99,9 @@ docker run --rm -it -v /path/to/data:/data \
   tmexp train-artm --bow-name my-bow --exp-name my-artm-exp --min-docs-abs 1
 ```
 
-Once your job is finished, the output files should be located in `/path/to/data/topics/my-bow/my-artm-exp`.
+Once this job is finished, the output files should be located in `/path/to/data/topics/my-bow/my-artm-exp`.
 
-### Train HDP
+### `train-hdp`command
 
 This command will allow you to create an HDP model from the bags-of-words created previously. You can launch the training with the following command (don't forget to specify the bow name):
 
@@ -110,4 +110,15 @@ docker run --rm -it -v /path/to/data:/data \
   tmexp train-hdp --bow-name my-bow --exp-name my-hdp-exp
 ```
 
-Once your job is finished, the output files should be located in `/path/to/data/topics/my-bow/my-hdp-exp`.
+Once this job is finished, the output files should be located in `/path/to/data/topics/my-bow/my-hdp-exp`.
+
+### `label` command
+
+This command automatically computes labels for topics of a previously created model (don't forget to specify the bow and experience name):
+
+```
+docker run --rm -it -v /path/to/data:/data \
+  tmexp label --bow-name my-bow --exp-name my-artm-exp
+```
+
+Once this job is finished, the output files should be located in `/path/to/data/topics/my-bow/my-artm-exp`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 nltk==3.4.3
 pymysql==0.9.3
-bblfsh==3.0.4
+bblfsh==3.1.1
 tqdm==4.32.2
 gensim==3.7.3
 matplotlib==3.1.1

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     install_requires=[
         "nltk==3.4.3",
         "pymysql==0.9.3",
-        "bblfsh==3.0.4",
+        "bblfsh==3.1.1",
         "tqdm==4.32.2",
         "gensim==3.7.3",
         "matplotlib==3.1.1",

--- a/tmexp/create_bow.py
+++ b/tmexp/create_bow.py
@@ -214,9 +214,9 @@ def create_bow(
         for doc_name in sorted(evolution_model):
             doc_evolution = evolution_model[doc_name]
             for i, refs in enumerate(doc_evolution.refs):
-                doc_name = SEP.join([doc_name, str(i)])
-                document_index[doc_name] = num_docs
-                fout.write(" ".join([doc_name] + refs) + "\n")
+                doc_name_ind = SEP.join([doc_name, str(i)])
+                document_index[doc_name_ind] = num_docs
+                fout.write(" ".join([doc_name_ind] + refs) + "\n")
                 num_docs += 1
     logger.info("Number of distinct documents : %d" % num_docs)
     logger.info("Saved document index in '%s'" % doc_output_path)
@@ -244,10 +244,10 @@ def create_bow(
         fout.write("%d\n" * 3 % (num_docs, num_words, num_nnz))
         for doc_name, doc_evolution in evolution_model.items():
             for i, bow in enumerate(doc_evolution.bows):
-                doc_name = SEP.join([doc_name, str(i)])
+                doc_name_ind = SEP.join([doc_name, str(i)])
                 for word, count in bow.items():
                     fout.write(
                         "%d %d %d\n"
-                        % (document_index[doc_name], word_index[word], count)
+                        % (document_index[doc_name_ind], word_index[word], count)
                     )
     logger.info("Saved bags of words in '%s'" % docword_output_path)

--- a/tmexp/create_bow.py
+++ b/tmexp/create_bow.py
@@ -1,5 +1,4 @@
 from argparse import ArgumentParser
-from collections import Counter
 import os
 import pickle
 from typing import Dict, List, Optional, Set
@@ -7,17 +6,14 @@ from typing import Dict, List, Optional, Set
 import tqdm
 
 from .cli import CLIBuilder, register_command
+from .data import Dataset, DocumentEvolution, EvolutionModel, RefList, WordCount
 from .io_constants import (
     BOW_DIR,
-    Dataset,
     DATASET_DIR,
     DOC_FILENAME,
-    DocumentEvolution,
     DOCWORD_FILENAME,
-    EvolutionModel,
     REF_FILENAME,
     VOCAB_FILENAME,
-    WordCount,
 )
 from .utils import (
     check_file_exists,
@@ -104,15 +100,15 @@ def create_bow(
 
     logger.info("Creating topic evolution model  ...")
     langs = create_language_list(langs, exclude_langs)
-    evolution_model: EvolutionModel = {}
-    doc_freq: WordCount = Counter()
+    evolution_model = EvolutionModel()
+    doc_freq = WordCount()
     num_blobs = 0
     for repo, files_content in input_dataset.files_content.items():
         logger.info("Processing repository '%s'", repo)
         for file_path, blobs in tqdm.tqdm(files_content.items()):
             bows: Dict[str, WordCount] = {}
             for blob_hash, feature_dict in blobs.items():
-                bow: WordCount = Counter()
+                bow = WordCount()
                 for feature in features:
                     if feature not in feature_dict:
                         continue
@@ -129,7 +125,7 @@ def create_bow(
                     if not seen_blobs:
                         continue
                     cur_blob_hash = None
-                    cur_bow: WordCount = Counter()
+                    cur_bow = WordCount()
                 else:
                     if file_info.language not in langs:
                         break
@@ -140,7 +136,7 @@ def create_bow(
                     doc_evolution.refs[-1].append(ref)
                 else:
                     doc_evolution.bows.append(cur_bow)
-                    doc_evolution.refs.append([ref])
+                    doc_evolution.refs.append(RefList([ref]))
                     prev_blob_hash = cur_blob_hash
             if not doc_evolution.bows:
                 continue
@@ -150,7 +146,7 @@ def create_bow(
             else:
                 added_evolution = DocumentEvolution(bows=[], refs=[])
                 removed_evolution = DocumentEvolution(bows=[], refs=[])
-                prev_bow: WordCount = Counter()
+                prev_bow = WordCount()
                 for bow, refs in zip(doc_evolution.bows, doc_evolution.refs):
                     added_evolution.bows.append(bow - prev_bow)
                     added_evolution.refs.append(refs)

--- a/tmexp/data.py
+++ b/tmexp/data.py
@@ -1,0 +1,112 @@
+from typing import Any, Counter, DefaultDict, Dict, List, NamedTuple, Set
+
+
+class FileInfo(NamedTuple):
+    blob_hash: str
+    language: str
+
+
+class RefInfo(Dict[str, FileInfo]):
+    pass
+
+
+class FilesInfo(Dict[str, RefInfo]):
+    def __init__(self, refs: List[str]):
+        super().__init__()
+        for ref in refs:
+            self[ref] = RefInfo()
+
+    def remove(self, file_path: str, blob_hash: str) -> None:
+        for ref_dict in self.values():
+            if file_path in ref_dict and blob_hash == ref_dict[file_path].blob_hash:
+                ref_dict.pop(file_path)
+
+
+class WordCount(Counter[str]):
+    def __sub__(self, other):  # type: ignore
+        if not isinstance(other, WordCount):
+            return NotImplemented
+        result = WordCount()
+        for elem in set(self) | set(other):
+            newcount = self[elem] - other[elem]
+            if newcount > 0:
+                result[elem] = newcount
+        return result
+
+
+class FeatureContent(Dict[str, WordCount]):
+    def __init__(self, features: List[str]):
+        for feature in features:
+            self[feature] = WordCount()
+
+
+class BlobContent(Dict[str, FeatureContent]):
+    pass
+
+
+class FilesContent(Dict[str, BlobContent]):
+    def __init__(self, files_info: FilesInfo):
+        super().__init__()
+        for ref_dict in files_info.values():
+            for file_path in ref_dict:
+                self[file_path] = BlobContent()
+
+    def purge(self, blacklist: Set[str]) -> None:
+        for file_path in blacklist:
+            self.pop(file_path)
+
+    def map_words(self, mapping: Dict[str, str]) -> None:
+        for file_path, blob_dict in self.items():
+            for blob_hash, feature_dict in blob_dict.items():
+                for feature, word_dict in feature_dict.items():
+                    new_wc = WordCount()
+                    for word, count in word_dict.items():
+                        new_wc[mapping[word]] = count
+                    self[file_path][blob_hash][feature] = new_wc
+
+
+class Dataset(NamedTuple):
+    files_info: Dict[str, FilesInfo] = {}
+    files_content: Dict[str, FilesContent] = {}
+    refs: Dict[str, List[str]] = {}
+
+
+# ------------------------------------------------------------------
+
+
+class RefList(List[str]):
+    pass
+
+
+class DocumentEvolution(NamedTuple):
+    bows: List[WordCount]
+    refs: List[RefList]
+
+
+class EvolutionModel(Dict[str, DocumentEvolution]):
+    pass
+
+
+# ------------------------------------------------------------------
+
+
+class DeltaMapping(Dict[str, int]):
+    pass
+
+
+class RefMapping(DefaultDict[str, DeltaMapping]):
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self.default_factory = DeltaMapping  # type: ignore
+
+
+class DocMapping(DefaultDict[str, RefMapping]):
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self.default_factory = RefMapping  # type: ignore
+
+
+class RepoMapping(DefaultDict[str, DocMapping]):
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self.default_factory = DocMapping  # type: ignore

--- a/tmexp/io_constants.py
+++ b/tmexp/io_constants.py
@@ -1,5 +1,5 @@
 from collections import Counter
-from typing import Counter as CounterType, Dict, List, NamedTuple, Set
+from typing import Counter as CounterType, DefaultDict, Dict, List, NamedTuple, Set
 
 DATASET_DIR = "/data/datasets"
 
@@ -80,6 +80,13 @@ MEMBERSHIP_FILENAME = "membership.pkl"
 WORDCOUNT_FILENAME = "wordcount.pkl"
 METRICS_FILENAME = "metrics.pkl"
 LABELS_FILENAME = "labels.txt"
+
+
+DeltaMapping = Dict[str, int]
+RefMapping = DefaultDict[str, DeltaMapping]
+DocMapping = DefaultDict[str, RefMapping]
+RepoMapping = DefaultDict[str, DocMapping]
+
 
 VIZ_DIR = "/data/visualisations"
 HEATMAP_FILENAME = "heatmap_%s.png"

--- a/tmexp/io_constants.py
+++ b/tmexp/io_constants.py
@@ -1,77 +1,10 @@
-from collections import Counter
-from typing import Counter as CounterType, DefaultDict, Dict, List, NamedTuple, Set
-
 DATASET_DIR = "/data/datasets"
-
-
-class FileInfo(NamedTuple):
-    blob_hash: str
-    language: str
-
-
-RefInfo = Dict[str, FileInfo]
-
-
-class FilesInfo(Dict[str, RefInfo]):
-    def __init__(self, refs: List[str]):
-        super().__init__()
-        for ref in refs:
-            self[ref] = {}
-
-    def remove(self, file_path: str, blob_hash: str) -> None:
-        for ref_dict in self.values():
-            if file_path in ref_dict and blob_hash == ref_dict[file_path].blob_hash:
-                ref_dict.pop(file_path)
-
-
-WordCount = CounterType[str]
-FeatureContent = Dict[str, WordCount]
-BlobContent = Dict[str, FeatureContent]
-
-
-class FilesContent(Dict[str, BlobContent]):
-    def __init__(self, files_info: FilesInfo):
-        super().__init__()
-        for ref_dict in files_info.values():
-            for file_path in ref_dict:
-                self[file_path] = {}
-
-    def purge(self, blacklist: Set[str]) -> None:
-        for file_path in blacklist:
-            self.pop(file_path)
-
-    def map_words(self, mapping: Dict[str, str]) -> None:
-        for file_path, blob_dict in self.items():
-            for blob_hash, feature_dict in blob_dict.items():
-                for feature, word_dict in feature_dict.items():
-                    new_wc: WordCount = Counter()
-                    for word, count in word_dict.items():
-                        new_wc[mapping[word]] = count
-                    self[file_path][blob_hash][feature] = new_wc
-
-
-class Dataset(NamedTuple):
-    files_info: Dict[str, FilesInfo] = {}
-    files_content: Dict[str, FilesContent] = {}
-    refs: Dict[str, List[str]] = {}
-
 
 BOW_DIR = "/data/bows"
 DOC_FILENAME = "doc.bow_tm.txt"
 DOCWORD_FILENAME = "docword.bow_tm.txt"
 REF_FILENAME = "refs.bow_tm.txt"
 VOCAB_FILENAME = "vocab.bow_tm.txt"
-
-RefList = List[str]
-
-
-class DocumentEvolution(NamedTuple):
-    bows: List[WordCount]
-    refs: List[RefList]
-
-
-EvolutionModel = Dict[str, DocumentEvolution]
-
 
 TOPICS_DIR = "/data/topics"
 DOCTOPIC_FILENAME = "doctopic.npy"
@@ -80,13 +13,6 @@ MEMBERSHIP_FILENAME = "membership.pkl"
 WORDCOUNT_FILENAME = "wordcount.pkl"
 METRICS_FILENAME = "metrics.pkl"
 LABELS_FILENAME = "labels.txt"
-
-
-DeltaMapping = Dict[str, int]
-RefMapping = DefaultDict[str, DeltaMapping]
-DocMapping = DefaultDict[str, RefMapping]
-RepoMapping = DefaultDict[str, DocMapping]
-
 
 VIZ_DIR = "/data/visualisations"
 HEATMAP_FILENAME = "heatmap_%s.png"

--- a/tmexp/label.py
+++ b/tmexp/label.py
@@ -8,14 +8,13 @@ import numpy as np
 
 from .cli import CLIBuilder, register_command
 from .create_bow import ADD, DEL, DIFF_MODEL, HALL_MODEL, SEP
+from .data import RefList, RepoMapping
 from .io_constants import (
     BOW_DIR,
     DOC_FILENAME,
     DOCWORD_FILENAME,
     LABELS_FILENAME,
     REF_FILENAME,
-    RefList,
-    RepoMapping,
     TOPICS_DIR,
     VOCAB_FILENAME,
     WORDTOPIC_FILENAME,
@@ -103,9 +102,7 @@ def label(
         if SEP + ADD in line or SEP + DEL in line:
             topic_model, doc_type = DIFF_MODEL, "delta-documents"
             fin.seek(0)
-            repo_mapping: RepoMapping = defaultdict(
-                lambda: defaultdict(lambda: defaultdict(dict))
-            )
+            repo_mapping = RepoMapping()
             for doc_ind, line in enumerate(fin):
                 doc_info = line.split()
                 repo, file_path, delta_type, _ = doc_info[0].split(SEP)
@@ -129,7 +126,7 @@ def label(
     if topic_model == DIFF_MODEL:
         logger.info("Loading tagged refs ...")
         with open(refs_input_path, "r", encoding="utf-8") as fin:
-            refs: DefaultDict[str, RefList] = defaultdict(list)
+            refs: DefaultDict[str, RefList] = defaultdict(RefList)
             for line in fin:
                 repo, ref = line.split(SEP)
                 refs[repo].append(ref.replace("\n", ""))

--- a/tmexp/label.py
+++ b/tmexp/label.py
@@ -2,18 +2,20 @@ from argparse import ArgumentParser
 from collections import defaultdict
 import itertools
 import os
-from typing import Dict, List, Union
+from typing import DefaultDict, Dict, List, Union
 
 import numpy as np
 
 from .cli import CLIBuilder, register_command
-from .create_bow import DIFF_MODEL, HALL_MODEL, SEP
+from .create_bow import ADD, DEL, DIFF_MODEL, HALL_MODEL, SEP
 from .io_constants import (
     BOW_DIR,
     DOC_FILENAME,
     DOCWORD_FILENAME,
     LABELS_FILENAME,
     REF_FILENAME,
+    RefList,
+    RepoMapping,
     TOPICS_DIR,
     VOCAB_FILENAME,
     WORDTOPIC_FILENAME,
@@ -98,17 +100,24 @@ def label(
     logger.info("Loading document index ...")
     with open(doc_input_path, "r", encoding="utf-8") as fin:
         line = fin.readline()
-        if ":added" in line or ":removed" in line:
+        if SEP + ADD in line or SEP + DEL in line:
             topic_model, doc_type = DIFF_MODEL, "delta-documents"
             fin.seek(0)
-            doc_index = fin.read().split("\n")
+            repo_mapping: RepoMapping = defaultdict(
+                lambda: defaultdict(lambda: defaultdict(dict))
+            )
+            for doc_ind, line in enumerate(fin):
+                doc_info = line.split()
+                repo, file_path, delta_type, _ = doc_info[0].split(SEP)
+                first_ref = doc_info[1]
+                repo_mapping[repo][file_path][first_ref][delta_type] = doc_ind
+
         else:
             topic_model, doc_type = HALL_MODEL, "documents"
     logger.info("Loaded document index, detected %s topic model." % topic_model)
 
     logger.info("Loading bags of words ...")
     with open(docword_input_path, "r", encoding="utf-8") as fin:
-
         num_docs = int(fin.readline())
         num_words = int(fin.readline())
         num_bags = int(fin.readline())
@@ -120,33 +129,43 @@ def label(
     if topic_model == DIFF_MODEL:
         logger.info("Loading tagged refs ...")
         with open(refs_input_path, "r", encoding="utf-8") as fin:
-            refs = fin.read().split("\n")
-        logger.info("Loaded tagged refs, found %d." % len(refs))
-
+            refs: DefaultDict[str, RefList] = defaultdict(list)
+            for line in fin:
+                repo, ref = line.split(SEP)
+                refs[repo].append(ref.replace("\n", ""))
+        logger.info("Loaded tagged refs:")
+        for repo, repo_refs in refs.items():
+            logger.info("\tRepository '%s': %d refs", repo, len(repo_refs))
         logger.info("Recreating hall model corpus (we can't use %s) ..." % doc_type)
-        doc_ref: Dict[str, Dict[str, Dict[str, int]]] = defaultdict(
-            lambda: defaultdict(dict)
-        )
-        for ind_doc in range(num_docs):
-            name_refs = doc_index[ind_doc].split()
-            doc_name, doc_type, _ = name_refs[0].split(SEP)
-            ref = name_refs[1]
-            doc_ref[doc_name][ref][doc_type] = ind_doc
-        num_docs = len([_ for ref_dict in doc_ref.values() for ref in ref_dict])
+
         new_corpus = np.zeros((num_docs, num_words))
         cur_doc = 0
-        for ref_dict in doc_ref.values():
-            cur_doc_counts: np.array = np.zeros(num_words)
-            for ref in refs:
-                if ref not in ref_dict:
-                    continue
-                if "added" in ref_dict[ref]:
-                    cur_doc_counts += corpus[ref_dict[ref]["added"]]
-                if "removed" in ref_dict[ref]:
-                    cur_doc_counts -= corpus[ref_dict[ref]["removed"]]
-                if cur_doc_counts.any():
-                    new_corpus[cur_doc] = cur_doc_counts
-                    cur_doc += 1
+        for repo, doc_mapping in repo_mapping.items():
+            logger.info("\tProcessing repository '%s'", repo)
+            old_num_docs = sum(
+                len(delta_mapping)
+                for ref_mapping in doc_mapping.values()
+                for delta_mapping in ref_mapping.values()
+            )
+            new_num_docs = 0
+            for ref_mapping in doc_mapping.values():
+                cur_count: np.ndarray = np.zeros(num_words)
+                for ref in refs[repo]:
+                    if ref not in ref_mapping:
+                        continue
+                    if ADD in ref_mapping[ref]:
+                        cur_count += corpus[ref_mapping[ref][ADD]]
+                    if DEL in ref_mapping[ref]:
+                        cur_count += corpus[ref_mapping[ref][DEL]]
+                    if cur_count.any():
+                        new_corpus[cur_doc] = cur_count
+                        cur_doc += 1
+                        new_num_docs += 1
+            logger.info(
+                "Extracted %d documents out of %d delta-documents",
+                new_num_docs,
+                old_num_docs,
+            )
         num_docs = cur_doc
         corpus = new_corpus[:num_docs]
         logger.info("Recreated hall model corpus, found %d documents ..." % num_docs)

--- a/tmexp/merge.py
+++ b/tmexp/merge.py
@@ -4,7 +4,8 @@ import pickle
 from typing import List
 
 from .cli import CLIBuilder, register_command
-from .io_constants import Dataset, DATASET_DIR
+from .data import Dataset
+from .io_constants import DATASET_DIR
 from .utils import check_file_exists, check_remove, create_logger, recursive_update
 
 


### PR DESCRIPTION
So a couple commits here:

- bugfix on create-bow (doc index)
- added types for label
- updated README
- refactored label: added repo management, and better typing

I have a question btw, as you recall in order to compute the 1st order relevance score for a given model we need a context. Currently, we use the set of documents in the dataset **in the HALL format** as context, which means if a document does not change between n references, it is included `1` time, and not `n`, in the context.

Do you think this is the best way ? I was wondering whether we should:
- either not convert to the Hall model in the case of the Diff model 
- or stop deduplicating and include each document as many times as it appears, regardless if it's clones or not

The rational behind the first point would be that it would be closer to the data the topic model got to train. However as written in Mei's paper they don't hesitate to use different contexts, and furthermore since identifiers will be grouped by appearance/disappearance, we may not discover labels between identifiers that appeared at different times. Hence personnaly I don't really like this.

The second point makes more sense in my view, as if for example a document stays the same for 99 refs, then on the 100th ref one identifier is added, then that identifier's probability in the context will be clearly overstated.

So what do you think ? If we do this, I would like to push it in this PR, as it would not be very hard.