### PR TITLE
Bugfixes and refactoring

### DIFF
--- a/tmexp/label.py
+++ b/tmexp/label.py
@@ -195,8 +195,8 @@ def concat_reducer(
     ref_mapping: RefMapping,
     cur_doc_ind: int,
 ) -> int:
-    prev_doc = np.zeros(corpus[0])
-    empty_doc = np.zeros(corpus[0])
+    prev_doc = np.zeros_like(corpus[0])
+    empty_doc = np.zeros_like(corpus[0])
     for ref in refs:
         if ref not in ref_mapping or DOC not in ref_mapping[ref]:
             continue

--- a/tmexp/utils.py
+++ b/tmexp/utils.py
@@ -1,6 +1,6 @@
 from collections.abc import Mapping, MutableMapping
 import logging
-from logging import Handler, Logger, LogRecord, NOTSET
+from logging import Formatter, Handler, Logger, LogRecord, NOTSET
 import os
 import shutil
 import time
@@ -41,6 +41,7 @@ CUR_TIME = None
 class TqdmLoggingHandler(Handler):
     def __init__(self, level: int = NOTSET) -> None:
         super().__init__(level)
+        self.formatter = Formatter("[%(levelname)s] %(message)s")
 
     def emit(self, record: LogRecord) -> None:
         try:


### PR DESCRIPTION
So this includes a number of bug fixes, and another refactoring of `create-artm`. (mosltly included in the second commit). The related issue is #33 

### commit 1

Replaces `zeros` with `zeros_like` in label - error on my part in previous previous PR.

### commit 3

We did not have the log-level in logging for some time, this is now fixed (may require more changes later for pretty logging in a number of commands, but since this is cosmetic it is postponed to later).

### commit 2

The big one, so I'll go into  all changes:

- args: remove `converge-metric` - as detailed later, I don't think we should rely on this score, as there is no easy way to compute it ourselves, no way to check the one provided by BigARTM is bugged or not, and research shows it is often not the best metric.
- add `check_doctopic`: helper function with DEBUG log to check sanity of doc-topic matrix. it is also used before saving the model data (which does not happen if the matrix is corrupt)
- modify `create_artm_batch_vectorizer`: cosmetic change in logging
- modify `print_scores`: cosmetic change in logging, added `header` arg as it is used in multiple places
- modify `compute_scores`: doc-topic sparsity is being computed, perplexity is out 
- modify `loop_until_convergence`: renamed as it is redefined in `create_bow` (for readability as most args are constant), now returns score and num_iter, and minor changes. if not `quiet`, we only print every 25 global iterations
- add `_save_model`: like above, it is redefined in the function. all saving logic is now in this function, as we will save twice now
- modify `create-bow`:
    - bug when computing relative `min_docs` is corrected
    - removed unused scores from model
    - global number of iterations is bow being tracked
    - `loop_until_convergence` and `save_model` are defined here for readability
    - added `check_doctopic` and `print_scores` after each training loop (and removing topics for the latter)
    - added intermediate save
    - added check on score before/after sparsity inducing to not save if quality decreased.