### PR TITLE
Refactor postprocess

### DIFF
--- a/tmexp/constants.py
+++ b/tmexp/constants.py
@@ -1,0 +1,6 @@
+DIFF_MODEL = "diff"
+HALL_MODEL = "hall"
+SEP = ":"
+ADD = "added"
+DEL = "removed"
+DOC = "doc"

--- a/tmexp/create_bow.py
+++ b/tmexp/create_bow.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Optional, Set
 import tqdm
 
 from .cli import CLIBuilder, register_command
+from .constants import ADD, DEL, DIFF_MODEL, HALL_MODEL, SEP
 from .data import Dataset, DocumentEvolution, EvolutionModel, RefList, WordCount
 from .io_constants import (
     BOW_DIR,
@@ -25,12 +26,6 @@ from .utils import (
     create_language_list,
     create_logger,
 )
-
-DIFF_MODEL = "diff"
-HALL_MODEL = "hall"
-SEP = ":"
-ADD = "added"
-DEL = "removed"
 
 
 def _define_parser(parser: ArgumentParser) -> None:

--- a/tmexp/create_bow.py
+++ b/tmexp/create_bow.py
@@ -119,7 +119,7 @@ def create_bow(
                 doc_freq.update(bow.keys())
             doc_evolution = DocumentEvolution(bows=[], refs=[])
             seen_blobs: Set[str] = set()
-            refs = input_dataset.refs[repo]
+            refs = input_dataset.refs_dict[repo]
             prev_bow = None
             for ref in refs:
                 file_info = input_dataset.files_info[repo][ref].get(file_path)
@@ -193,8 +193,8 @@ def create_bow(
 
     logger.info("Saving tagged refs ...")
     with open(refs_output_path, "w", encoding="utf-8") as fout:
-        for repo, repo_refs in input_dataset.refs.items():
-            for ref in repo_refs:
+        for repo, refs in input_dataset.refs_dict.items():
+            for ref in refs:
                 fout.write("%s%s%s\n" % (repo, SEP, ref))
     logger.info("Saved tagged refs in '%s'" % refs_output_path)
 

--- a/tmexp/data.py
+++ b/tmexp/data.py
@@ -179,3 +179,38 @@ class RepoMapping(DefaultDict[str, FileMapping]):
             logger.info("\tExtracted %d documents.", new_num_docs)
         num_docs = cur_doc_ind + 1
         return new_corpus[:num_docs]
+
+
+# ------------------------------------------------------------------
+
+
+class DocWordCounts(Dict[str, int]):
+    pass
+
+
+class RefWordCounts(DefaultDict[str, DocWordCounts]):
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self.default_factory = DocWordCounts  # type: ignore
+
+
+class RepoWordCounts(DefaultDict[str, RefWordCounts]):
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self.default_factory = RefWordCounts  # type: ignore
+
+
+class DocMembership(Dict[str, np.array]):
+    pass
+
+
+class RefMembership(DefaultDict[str, DocMembership]):
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self.default_factory = DocMembership  # type: ignore
+
+
+class RepoMembership(DefaultDict[str, RefMembership]):
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self.default_factory = RefMembership  # type: ignore

--- a/tmexp/data.py
+++ b/tmexp/data.py
@@ -1,6 +1,4 @@
-from typing import Any, Callable, Counter, DefaultDict, Dict, List, NamedTuple, Set
-
-import numpy as np
+from typing import Any, Counter, DefaultDict, Dict, List, NamedTuple, Set
 
 
 class FileInfo(NamedTuple):
@@ -112,6 +110,3 @@ class RepoMapping(DefaultDict[str, FileMapping]):
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
         self.default_factory = FileMapping  # type: ignore
-
-
-FileReducer = Callable[[np.ndarray, np.ndarray, RefList, RefMapping, int], int]

--- a/tmexp/label.py
+++ b/tmexp/label.py
@@ -3,15 +3,14 @@ from collections import defaultdict
 from enum import Enum
 from functools import partial
 import itertools
-import logging
 import os
-from typing import Callable, DefaultDict, Dict, List, Optional, Union
+from typing import DefaultDict, Dict, List, Optional, Union
 
 import numpy as np
 
 from .cli import CLIBuilder, register_command
-from .create_bow import ADD, DEL, DIFF_MODEL, HALL_MODEL, SEP
-from .data import FileReducer, RefList, RefMapping, RepoMapping
+from .constants import ADD, DEL, DIFF_MODEL, DOC, HALL_MODEL, SEP
+from .data import RefList, RepoMapping
 from .io_constants import (
     BOW_DIR,
     DOC_FILENAME,
@@ -22,9 +21,17 @@ from .io_constants import (
     VOCAB_FILENAME,
     WORDTOPIC_FILENAME,
 )
+from .reduce import (
+    concat_reducer,
+    diff_to_hall_reducer,
+    FileReducer,
+    last_ref_reducer,
+    max_reducer,
+    mean_reducer,
+    median_reducer,
+    reduce_corpus,
+)
 from .utils import check_file_exists, check_range, check_remove, create_logger
-
-DOC = "doc"
 
 
 def _define_parser(parser: ArgumentParser) -> None:
@@ -73,137 +80,6 @@ def _define_parser(parser: ArgumentParser) -> None:
         type=Context.from_string,
         required=True,
     )
-
-
-def reduce_corpus(
-    corpus: np.ndarray,
-    logger: logging.Logger,
-    repo_mapping: RepoMapping,
-    refs: DefaultDict[str, RefList],
-    file_reducer: FileReducer,
-) -> np.ndarray:
-    new_corpus = np.zeros_like(corpus)
-    cur_doc_ind = -1
-    for repo, file_mapping in repo_mapping.items():
-        logger.info("\tProcessing repository '%s'", repo)
-        new_num_docs = 0
-        for ref_mapping in file_mapping.values():
-            num_added_docs = file_reducer(
-                corpus, new_corpus, refs[repo], ref_mapping, cur_doc_ind
-            )
-            new_num_docs += num_added_docs
-            cur_doc_ind += num_added_docs
-        logger.info("\tExtracted %d documents.", new_num_docs)
-    num_docs = cur_doc_ind + 1
-    return new_corpus[:num_docs]
-
-
-def diff_to_hall_reducer(
-    corpus: np.ndarray,
-    new_corpus: np.ndarray,
-    refs: RefList,
-    ref_mapping: RefMapping,
-    cur_doc_ind: int,
-) -> int:
-    cur_count: np.ndarray = np.zeros_like(corpus[0])
-    prev_add_doc, prev_del_doc = None, None
-    new_num_docs = 0
-    for ref in refs:
-        if ref not in ref_mapping:
-            continue
-        cur_add_doc = ref_mapping[ref].get(ADD)
-        cur_del_doc = ref_mapping[ref].get(DEL)
-
-        new_doc = cur_add_doc != prev_add_doc or cur_del_doc != prev_del_doc
-        if new_doc:
-            if cur_add_doc != prev_add_doc:
-                cur_count += corpus[cur_add_doc]
-                prev_add_doc = cur_add_doc
-            if cur_del_doc != prev_del_doc:
-                cur_count -= corpus[cur_del_doc]
-                prev_del_doc = cur_del_doc
-        if cur_count.any():
-            new_num_docs += int(new_doc)
-            new_corpus[cur_doc_ind + new_num_docs] = cur_count
-            ref_mapping[ref][DOC] = cur_doc_ind + new_num_docs
-    return new_num_docs
-
-
-def last_ref_reducer(
-    corpus: np.ndarray,
-    new_corpus: np.ndarray,
-    refs: RefList,
-    ref_mapping: RefMapping,
-    cur_doc_ind: int,
-) -> int:
-    if refs[-1] in ref_mapping and DOC in ref_mapping[refs[-1]]:
-        new_corpus[cur_doc_ind + 1] = corpus[ref_mapping[refs[-1]][DOC]]
-    return 1
-
-
-def numpy_op_reducer(
-    corpus: np.ndarray,
-    new_corpus: np.ndarray,
-    _: RefList,
-    ref_mapping: RefMapping,
-    cur_doc_ind: int,
-    numpy_op: Callable[..., np.ndarray],
-) -> int:
-    doc_inds = [
-        doc_mapping[DOC] for doc_mapping in ref_mapping.values() if DOC in doc_mapping
-    ]
-    new_corpus[cur_doc_ind + 1] = numpy_op(corpus[doc_inds], axis=0)
-    return 1
-
-
-def max_reducer(
-    corpus: np.ndarray,
-    new_corpus: np.ndarray,
-    refs: RefList,
-    ref_mapping: RefMapping,
-    cur_doc_ind: int,
-) -> int:
-    return numpy_op_reducer(corpus, new_corpus, refs, ref_mapping, cur_doc_ind, np.max)
-
-
-def mean_reducer(
-    corpus: np.ndarray,
-    new_corpus: np.ndarray,
-    refs: RefList,
-    ref_mapping: RefMapping,
-    cur_doc_ind: int,
-) -> int:
-    return numpy_op_reducer(corpus, new_corpus, refs, ref_mapping, cur_doc_ind, np.mean)
-
-
-def median_reducer(
-    corpus: np.ndarray,
-    new_corpus: np.ndarray,
-    refs: RefList,
-    ref_mapping: RefMapping,
-    cur_doc_ind: int,
-) -> int:
-    return numpy_op_reducer(
-        corpus, new_corpus, refs, ref_mapping, cur_doc_ind, np.median
-    )
-
-
-def concat_reducer(
-    corpus: np.ndarray,
-    new_corpus: np.ndarray,
-    refs: RefList,
-    ref_mapping: RefMapping,
-    cur_doc_ind: int,
-) -> int:
-    prev_doc = np.zeros_like(corpus[0])
-    empty_doc = np.zeros_like(corpus[0])
-    for ref in refs:
-        if ref not in ref_mapping or DOC not in ref_mapping[ref]:
-            continue
-        cur_doc = corpus[ref_mapping[ref][DOC]]
-        new_corpus[cur_doc_ind] += np.maximum(empty_doc, cur_doc - prev_doc)
-        prev_doc = cur_doc
-    return 1
 
 
 class Context(Enum):

--- a/tmexp/label.py
+++ b/tmexp/label.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from .cli import CLIBuilder, register_command
 from .constants import DIFF_MODEL, SEP
-from .data import RefList, RepoMapping
+from .data import FileReducer, RefList, RepoMapping
 from .io_constants import (
     BOW_DIR,
     DOC_FILENAME,
@@ -24,12 +24,10 @@ from .io_constants import (
 from .reduce import (
     concat_reducer,
     diff_to_hall_reducer,
-    FileReducer,
     last_ref_reducer,
     max_reducer,
     mean_reducer,
     median_reducer,
-    reduce_corpus,
 )
 from .utils import check_file_exists, check_range, check_remove, create_logger
 
@@ -162,13 +160,13 @@ def label(
     corpus = repo_mapping.create_corpus(logger, docword_input_path)
     if repo_mapping.topic_model == DIFF_MODEL:
         logger.info("Recreating hall model corpus (we can't use delta-documents) ...")
-        corpus = reduce_corpus(corpus, logger, repo_mapping, refs, diff_to_hall_reducer)
+        corpus = repo_mapping.reduce_corpus(corpus, logger, refs, diff_to_hall_reducer)
         num_docs = corpus.shape[0]
         logger.info("Recreated hall model corpus, found %d documents ...", num_docs)
 
     if context.reducer is not None:
         logger.info("Creating %s context ...", str(context))
-        corpus = reduce_corpus(corpus, logger, repo_mapping, refs, context.reducer)
+        corpus = repo_mapping.reduce_corpus(corpus, logger, refs, context.reducer)
         num_docs = corpus.shape[0]
         logger.info("Created context, found %d documents ...", num_docs)
 

--- a/tmexp/merge.py
+++ b/tmexp/merge.py
@@ -46,7 +46,7 @@ def merge(
         recursive_update(output_dataset.files_info, input_dataset.files_info)
         recursive_update(output_dataset.files_content, input_dataset.files_content)
 
-        for repo, refs in input_dataset.refs.items():
+        for repo, refs in input_dataset.refs_dict.items():
             if len(refs) > 1:
                 logger.warning(
                     "Found %d references for repository %s. Please make sure you "
@@ -54,11 +54,11 @@ def merge(
                     len(refs),
                     repo,
                 )
-            if repo not in output_dataset.refs:
+            if repo not in output_dataset.refs_dict:
                 logger.info("Adding new repository '%s' from '%s'.", repo, dataset_name)
-                output_dataset.refs[repo] = input_dataset.refs[repo]
+                output_dataset.refs_dict[repo] = input_dataset.refs_dict[repo]
             else:
-                if output_dataset.refs[repo] != input_dataset.refs[repo]:
+                if output_dataset.refs_dict[repo] != input_dataset.refs_dict[repo]:
                     logger.error(
                         "Discrepancy between references for repository '%s', data from "
                         "'%s' will not be added.",

--- a/tmexp/postprocess.py
+++ b/tmexp/postprocess.py
@@ -1,13 +1,12 @@
 from argparse import ArgumentParser
-from collections import Counter, defaultdict
 import os
 import pickle
-from typing import Counter as CounterType, DefaultDict, Dict
 
 import numpy as np
 
 from .cli import CLIBuilder, register_command
-from .constants import DIFF_MODEL, HALL_MODEL, SEP
+from .constants import ADD, DEL, DIFF_MODEL, DOC, HALL_MODEL
+from .data import RepoMapping, RepoMembership, RepoWordCounts
 from .io_constants import (
     BOW_DIR,
     DOC_FILENAME,
@@ -18,6 +17,7 @@ from .io_constants import (
     TOPICS_DIR,
     WORDCOUNT_FILENAME,
 )
+from .reduce import diff_to_hall_reducer
 from .utils import check_file_exists, check_remove, create_logger, load_refs_dict
 
 
@@ -33,117 +33,85 @@ def postprocess(bow_name: str, exp_name: str, force: bool, log_level: str) -> No
     """Compute document word count and membership given a topic model."""
     logger = create_logger(log_level, __name__)
 
-    input_dir_bow = os.path.join(BOW_DIR, bow_name)
+    dir_bow = os.path.join(BOW_DIR, bow_name)
     dir_exp = os.path.join(TOPICS_DIR, bow_name, exp_name)
-    doc_input_path = os.path.join(input_dir_bow, DOC_FILENAME)
+    doc_input_path = os.path.join(dir_bow, DOC_FILENAME)
     check_file_exists(doc_input_path)
-    docword_input_path = os.path.join(input_dir_bow, DOCWORD_FILENAME)
+    docword_input_path = os.path.join(dir_bow, DOCWORD_FILENAME)
     check_file_exists(docword_input_path)
-    refs_input_path = os.path.join(input_dir_bow, REF_FILENAME)
+    refs_input_path = os.path.join(dir_bow, REF_FILENAME)
     check_file_exists(refs_input_path)
 
     doctopic_input_path = os.path.join(dir_exp, DOCTOPIC_FILENAME)
     check_file_exists(doctopic_input_path)
 
+    wordcount_output_path = os.path.join(dir_bow, WORDCOUNT_FILENAME)
+    check_remove(wordcount_output_path, logger, force)
     membership_output_path = os.path.join(dir_exp, MEMBERSHIP_FILENAME)
     check_remove(membership_output_path, logger, force)
-    wordcount_output_path = os.path.join(dir_exp, WORDCOUNT_FILENAME)
-    check_remove(wordcount_output_path, logger, force)
 
     refs_dict = load_refs_dict(logger, refs_input_path)
 
     logger.info("Loading document topics matrix ...")
     doctopic = np.load(doctopic_input_path)
-    num_docs, num_topics = doctopic.shape
-    logger.info(
-        "Loaded matrix, found %d documents and %d topics.", num_docs, num_topics
-    )
+    num_topics = doctopic.shape[1]
+    logger.info("Loaded matrix, found %d topics.", num_topics)
 
-    logger.info("Loading document word counts ...")
-    docword: CounterType[int] = Counter()
-    with open(docword_input_path, "r", encoding="utf-8") as fin:
-        for _ in range(3):
-            fin.readline()
-        for line in fin:
-            ind_doc, _, count = map(int, line.split())
-            docword[ind_doc] += count
-    logger.info("Loaded word counts.")
+    memberships = RepoMembership()
+    total_word_counts = RepoWordCounts()
 
-    membership: DefaultDict[str, DefaultDict[str, Dict[str, np.array]]] = defaultdict(
-        lambda: defaultdict(dict)
-    )
-    wordcount: DefaultDict[str, DefaultDict[str, Dict[str, int]]] = defaultdict(
-        lambda: defaultdict(dict)
-    )
+    repo_mapping = RepoMapping()
+    repo_mapping.build(logger, doc_input_path)
 
-    logger.info("Loading document index ...")
-    with open(doc_input_path, "r", encoding="utf-8") as fin:
-        line = fin.readline()
-        if ":added" in line or ":removed" in line:
-            topic_model = DIFF_MODEL
-            diff_mapping: DefaultDict[
-                str, DefaultDict[str, DefaultDict[str, Dict[str, int]]]
-            ] = defaultdict(lambda: defaultdict(lambda: defaultdict(dict)))
-        else:
-            topic_model = HALL_MODEL
-        fin.seek(0)
-        doc_index = fin.read().split("\n")
-    logger.info("Loaded document index, detected %s topic model.", topic_model)
+    corpus = repo_mapping.create_corpus(logger, docword_input_path)
+    if repo_mapping.topic_model == DIFF_MODEL:
+        logger.info("Creating hall model corpus ...")
+        hall_corpus = repo_mapping.reduce_corpus(
+            corpus, logger, refs_dict, diff_to_hall_reducer
+        )
+        num_docs = hall_corpus.shape[0]
+        logger.info("Recreated hall model corpus, found %d documents ...", num_docs)
 
     logger.info("Computing topic membership and total word count per document ...")
-    for ind_doc in range(num_docs):
-        name_refs = doc_index[ind_doc].split()
-        doc_name = name_refs[0].split(SEP)
-        doc_repo = doc_name[0]
-        doc_path = doc_name[1]
-        doc_refs = name_refs[1:]
-        if topic_model == DIFF_MODEL:
-            doc_type = doc_name[2]
-            diff_mapping[doc_repo][doc_refs[0]][doc_path][doc_type] = ind_doc
-            for ref in doc_refs[1:]:
-                diff_mapping[ref][doc_path][doc_type] = None
-        else:
-            for ref in doc_refs:
-                membership[doc_repo][ref][doc_path] = doctopic[ind_doc, :]
-                wordcount[doc_repo][ref][doc_path] = docword[ind_doc]
-    if topic_model == DIFF_MODEL:
-
-        for repo, refs in refs_dict.items():
-            last_membership: DefaultDict[str, np.array] = defaultdict(
-                lambda: np.zeros(num_topics)
-            )
-            last_wordcount: CounterType[str] = Counter()
-            for ref in refs:
-                for doc_path, doc_mapping in diff_mapping[repo][ref].items():
-                    last = last_membership[doc_path]
-                    last_wc = last_wordcount[doc_path]
-                    add_wc, rem_wc = 0, 0
-                    add, rem = np.zeros(num_topics), np.zeros(num_topics)
-                    if "added" in doc_mapping and doc_mapping["added"] is not None:
-                        add_wc += docword[doc_mapping["added"]]
-                        add += doctopic[doc_mapping["added"], :]
-                    if "removed" in doc_mapping and doc_mapping["removed"] is not None:
-                        rem_wc += docword[doc_mapping["removed"]]
-                        rem += doctopic[doc_mapping["removed"], :]
-
-                    cur = np.zeros(num_topics)
-                    cur_wc = last_wc + add_wc - rem_wc
-                    if cur_wc:
-                        wordcount[repo][ref][doc_path] = cur_wc
-                        cur = (last * last_wc + add * add_wc - rem * rem_wc) / cur_wc
-                        cur[cur > 1] = 1
-                        cur[cur <= 0] = 1e-20
-                        membership[repo][ref][doc_path] = cur
-                    last_wordcount[doc_path] = cur_wc
-                    last_membership[doc_path] = cur
+    for repo, file_mapping in repo_mapping.items():
+        logger.info("\tProcessing repository '%s'", repo)
+        for doc_name, ref_mapping in file_mapping.items():
+            if repo_mapping.topic_model == HALL_MODEL:
+                for ref, doc_mapping in ref_mapping.items():
+                    ind_doc = doc_mapping[DOC]
+                    memberships[repo][ref][doc_name] = doctopic[ind_doc]
+                    total_word_counts[repo][ref][doc_name] = np.sum(corpus[ind_doc])
+            else:
+                prev_membership = np.zeros(num_topics)
+                prev_count = 0
+                for ref in refs_dict[repo]:
+                    if ref not in ref_mapping or DOC not in ref_mapping[ref]:
+                        prev_membership = np.zeros(num_topics)
+                        prev_count = 0
+                        continue
+                    ind_doc = ref_mapping[ref][DOC]
+                    count = np.sum(hall_corpus[ind_doc])
+                    membership = prev_membership * prev_count
+                    for key, mult in zip([ADD, DEL], [1, -1]):
+                        ind = ref_mapping[ref].get(key)
+                        if ind is not None:
+                            membership += mult * np.sum(corpus[ind]) * doctopic[ind]
+                    membership = membership / count
+                    membership[membership < 0] = 0
+                    membership[membership > 1] = 1
+                    membership = membership / np.sum(membership)
+                    memberships[repo][ref][doc_name] = membership
+                    total_word_counts[repo][ref][doc_name] = count
+                    prev_membership = membership
+                    prev_count = count
     logger.info("Computed topic membership per reference.")
 
     logger.info("Saving document memberships ...")
     with open(membership_output_path, "wb") as fout:
-        pickle.dump(dict(membership), fout)
+        pickle.dump(memberships, fout)
     logger.info("Saved memberships in '%s'." % membership_output_path)
 
     logger.info("Saving document total word counts ...")
     with open(wordcount_output_path, "wb") as fout:
-        pickle.dump(dict(wordcount), fout)
+        pickle.dump(total_word_counts, fout)
     logger.info("Saved word counts in '%s'." % wordcount_output_path)

--- a/tmexp/postprocess.py
+++ b/tmexp/postprocess.py
@@ -7,7 +7,7 @@ from typing import Counter as CounterType, DefaultDict, Dict, List
 import numpy as np
 
 from .cli import CLIBuilder, register_command
-from .create_bow import DIFF_MODEL, HALL_MODEL, SEP
+from .constants import DIFF_MODEL, HALL_MODEL, SEP
 from .io_constants import (
     BOW_DIR,
     DOC_FILENAME,

--- a/tmexp/reduce.py
+++ b/tmexp/reduce.py
@@ -1,0 +1,140 @@
+import logging
+from typing import Callable, DefaultDict
+
+import numpy as np
+
+from .constants import ADD, DEL, DOC
+from .data import RefList, RefMapping, RepoMapping
+
+FileReducer = Callable[[np.ndarray, np.ndarray, RefList, RefMapping, int], int]
+
+
+def reduce_corpus(
+    corpus: np.ndarray,
+    logger: logging.Logger,
+    repo_mapping: RepoMapping,
+    refs: DefaultDict[str, RefList],
+    file_reducer: FileReducer,
+) -> np.ndarray:
+    new_corpus = np.zeros_like(corpus)
+    cur_doc_ind = -1
+    for repo, file_mapping in repo_mapping.items():
+        logger.info("\tProcessing repository '%s'", repo)
+        new_num_docs = 0
+        for ref_mapping in file_mapping.values():
+            num_added_docs = file_reducer(
+                corpus, new_corpus, refs[repo], ref_mapping, cur_doc_ind
+            )
+            new_num_docs += num_added_docs
+            cur_doc_ind += num_added_docs
+        logger.info("\tExtracted %d documents.", new_num_docs)
+    num_docs = cur_doc_ind + 1
+    return new_corpus[:num_docs]
+
+
+def diff_to_hall_reducer(
+    corpus: np.ndarray,
+    new_corpus: np.ndarray,
+    refs: RefList,
+    ref_mapping: RefMapping,
+    cur_doc_ind: int,
+) -> int:
+    cur_count: np.ndarray = np.zeros_like(corpus[0])
+    prev_add_doc, prev_del_doc = None, None
+    new_num_docs = 0
+    for ref in refs:
+        if ref not in ref_mapping:
+            continue
+        cur_add_doc = ref_mapping[ref].get(ADD)
+        cur_del_doc = ref_mapping[ref].get(DEL)
+
+        new_doc = cur_add_doc != prev_add_doc or cur_del_doc != prev_del_doc
+        if new_doc:
+            if cur_add_doc != prev_add_doc:
+                cur_count += corpus[cur_add_doc]
+                prev_add_doc = cur_add_doc
+            if cur_del_doc != prev_del_doc:
+                cur_count -= corpus[cur_del_doc]
+                prev_del_doc = cur_del_doc
+        if cur_count.any():
+            new_num_docs += int(new_doc)
+            new_corpus[cur_doc_ind + new_num_docs] = cur_count
+            ref_mapping[ref][DOC] = cur_doc_ind + new_num_docs
+    return new_num_docs
+
+
+def last_ref_reducer(
+    corpus: np.ndarray,
+    new_corpus: np.ndarray,
+    refs: RefList,
+    ref_mapping: RefMapping,
+    cur_doc_ind: int,
+) -> int:
+    if refs[-1] in ref_mapping and DOC in ref_mapping[refs[-1]]:
+        new_corpus[cur_doc_ind + 1] = corpus[ref_mapping[refs[-1]][DOC]]
+    return 1
+
+
+def numpy_op_reducer(
+    corpus: np.ndarray,
+    new_corpus: np.ndarray,
+    _: RefList,
+    ref_mapping: RefMapping,
+    cur_doc_ind: int,
+    numpy_op: Callable[..., np.ndarray],
+) -> int:
+    doc_inds = [
+        doc_mapping[DOC] for doc_mapping in ref_mapping.values() if DOC in doc_mapping
+    ]
+    new_corpus[cur_doc_ind + 1] = numpy_op(corpus[doc_inds], axis=0)
+    return 1
+
+
+def max_reducer(
+    corpus: np.ndarray,
+    new_corpus: np.ndarray,
+    refs: RefList,
+    ref_mapping: RefMapping,
+    cur_doc_ind: int,
+) -> int:
+    return numpy_op_reducer(corpus, new_corpus, refs, ref_mapping, cur_doc_ind, np.max)
+
+
+def mean_reducer(
+    corpus: np.ndarray,
+    new_corpus: np.ndarray,
+    refs: RefList,
+    ref_mapping: RefMapping,
+    cur_doc_ind: int,
+) -> int:
+    return numpy_op_reducer(corpus, new_corpus, refs, ref_mapping, cur_doc_ind, np.mean)
+
+
+def median_reducer(
+    corpus: np.ndarray,
+    new_corpus: np.ndarray,
+    refs: RefList,
+    ref_mapping: RefMapping,
+    cur_doc_ind: int,
+) -> int:
+    return numpy_op_reducer(
+        corpus, new_corpus, refs, ref_mapping, cur_doc_ind, np.median
+    )
+
+
+def concat_reducer(
+    corpus: np.ndarray,
+    new_corpus: np.ndarray,
+    refs: RefList,
+    ref_mapping: RefMapping,
+    cur_doc_ind: int,
+) -> int:
+    prev_doc = np.zeros_like(corpus[0])
+    empty_doc = np.zeros_like(corpus[0])
+    for ref in refs:
+        if ref not in ref_mapping or DOC not in ref_mapping[ref]:
+            continue
+        cur_doc = corpus[ref_mapping[ref][DOC]]
+        new_corpus[cur_doc_ind] += np.maximum(empty_doc, cur_doc - prev_doc)
+        prev_doc = cur_doc
+    return 1

--- a/tmexp/reduce.py
+++ b/tmexp/reduce.py
@@ -1,35 +1,9 @@
-import logging
-from typing import Callable, DefaultDict
+from typing import Callable
 
 import numpy as np
 
 from .constants import ADD, DEL, DOC
-from .data import RefList, RefMapping, RepoMapping
-
-FileReducer = Callable[[np.ndarray, np.ndarray, RefList, RefMapping, int], int]
-
-
-def reduce_corpus(
-    corpus: np.ndarray,
-    logger: logging.Logger,
-    repo_mapping: RepoMapping,
-    refs: DefaultDict[str, RefList],
-    file_reducer: FileReducer,
-) -> np.ndarray:
-    new_corpus = np.zeros_like(corpus)
-    cur_doc_ind = -1
-    for repo, file_mapping in repo_mapping.items():
-        logger.info("\tProcessing repository '%s'", repo)
-        new_num_docs = 0
-        for ref_mapping in file_mapping.values():
-            num_added_docs = file_reducer(
-                corpus, new_corpus, refs[repo], ref_mapping, cur_doc_ind
-            )
-            new_num_docs += num_added_docs
-            cur_doc_ind += num_added_docs
-        logger.info("\tExtracted %d documents.", new_num_docs)
-    num_docs = cur_doc_ind + 1
-    return new_corpus[:num_docs]
+from .data import RefList, RefMapping
 
 
 def diff_to_hall_reducer(

--- a/tmexp/utils.py
+++ b/tmexp/utils.py
@@ -13,6 +13,9 @@ from typing import (
 
 import tqdm
 
+from .constants import SEP
+from .data import RefsDict
+
 # TODO: stop hardcoding when https://github.com/bblfsh/client-python/issues/168 is done
 SUPPORTED_LANGUAGES = [
     "C#",
@@ -149,3 +152,16 @@ def recursive_update(d: MutableMappingType, u: MappingType) -> None:
         return d
 
     recursive_worker(d, u)
+
+
+def load_refs_dict(logger: logging.Logger, input_path: str) -> RefsDict:
+    logger.info("Loading tagged refs ...")
+    with open(input_path, "r", encoding="utf-8") as fin:
+        refs_dict = RefsDict()
+        for line in fin:
+            repo, ref = line.split(SEP)
+            refs_dict[repo].append(ref.replace("\n", ""))
+    logger.info("Loaded tagged refs:")
+    for repo, refs in refs_dict.items():
+        logger.info("\tRepository '%s': %d refs", repo, len(refs))
+    return refs_dict


### PR DESCRIPTION
As updated in the issue, this is - hopefully - almost the last of the refactoring. Although the number of commits is important, most of it is just moving around code. I will leave open until monday, I test the code already but not extensively.

### commit 1

Create 2 files:
- `constants.py` for global constants that are not filenames or dirnames.
- `reduce.py` for all the corresponding logic in `label.py`

### commit 2

Add a `build` and `create_corpus` method to RepoMapping class. This makes `label` more readable, and also will avoid duplication as I will use that class in `postprocess`

### commit 3

Move the `reduce_corpus` to RepoMapping: same reasonning as above.

### commit 4

Create RefsDict data class and load_refs_dict function: more readable code, some deduplication

### commit 5

Add TotalWordsCount and repoMembership data classes for postporcess

### commit 6

Main refactoring of postprocess, using all of the logic in RepoMapping`

### commit 7

Update Readme.